### PR TITLE
context aware dictionary

### DIFF
--- a/lir/config/data_providers.py
+++ b/lir/config/data_providers.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 from lir import registry
 from lir.config.base import (
@@ -7,10 +6,11 @@ from lir.config.base import (
     GenericConfigParser,
     pop_field,
 )
+from lir.config.substitution import ContextAwareDict
 from lir.data.models import DataSet
 
 
-def parse_data_provider(cfg: dict[str, Any], context: list[str], output_path: Path) -> DataSet:
+def parse_data_provider(cfg: ContextAwareDict, output_path: Path) -> DataSet:
     """Instantiate specific implementation of `DataSetup` as configured.
 
     The `type` field is parsed, which is expected to refer to a name in
@@ -19,7 +19,7 @@ def parse_data_provider(cfg: dict[str, Any], context: list[str], output_path: Pa
 
     Data sources are provided under the `data_sources` key.
     """
-    provider = pop_field(context, cfg, "provider")
+    provider = pop_field(cfg, "provider")
 
     try:
         parser = registry.get(
@@ -29,8 +29,8 @@ def parse_data_provider(cfg: dict[str, Any], context: list[str], output_path: Pa
         )
     except Exception as e:
         raise YamlParseError(
-            context,
+            cfg.context,
             f"no parser available for data provider `{provider}`; the error was: {e}",
         )
 
-    return parser.parse(cfg, context, output_path)
+    return parser.parse(cfg, output_path)

--- a/lir/config/lrsystem_architectures.py
+++ b/lir/config/lrsystem_architectures.py
@@ -1,23 +1,18 @@
 import itertools
 import logging
 from pathlib import Path
-from typing import Any
-
-from confidence import Configuration
 
 from lir import registry
 from lir.config.base import (
     YamlParseError,
     config_parser,
     parse_pairing_config,
-    get_parser_arguments_for_field,
     pop_field,
 )
 from lir.config.substitution import (
-    validate_substitution_paths,
     substitute_hyperparameters,
     HyperparameterOption,
-    _expand,
+    ContextAwareDict,
 )
 from lir.config.transform import parse_module
 from lir.lrsystems.lrsystems import LRSystem, Pipeline
@@ -30,69 +25,59 @@ from lir.registry import ComponentNotFoundError
 LOG = logging.getLogger(__name__)
 
 
-def parse_pipeline(modules_config: Configuration, config_context_path: list[str], output_dir: Path) -> Pipeline:
+def parse_pipeline(modules_config: ContextAwareDict, output_dir: Path) -> Pipeline:
     """Construct a scikit-learn Pipeline based on the provided configuration."""
     if modules_config is None:
         return Pipeline([])
 
+    module_names = list(modules_config.keys())
     modules = [
         (
             module_name,
             parse_module(
-                modules_config.get(module_name),
-                config_context_path + [module_name],
+                pop_field(modules_config, module_name),
                 output_dir,
+                modules_config.context + [module_name],
             ),
         )
-        for module_name in modules_config
+        for module_name in module_names
     ]
 
     return Pipeline(modules)
 
 
 @config_parser
-def specific_source(config: dict[str, Any], config_context_path: list[str], output_dir: Path) -> LRSystem:
+def specific_source(config: ContextAwareDict, output_dir: Path) -> LRSystem:
     """Construct a specific-source LR system based on the provided configuration.
 
     The `specific_source` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.specific_source`.
     """
-    pipeline = parse_pipeline(*get_parser_arguments_for_field(config, config_context_path, output_dir, "modules"))
+    pipeline = parse_pipeline(pop_field(config, "modules"), output_dir)
     return SpecificSourceSystem(output_dir.name, pipeline)
 
 
 @config_parser
-def score_based(config: dict[str, Any], config_context_path: list[str], output_dir: Path) -> LRSystem:
+def score_based(config: ContextAwareDict, output_dir: Path) -> LRSystem:
     """Construct a specific-source LR system based on the provided configuration.
 
     The `specific_source` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.score_based`.
     """
-    preprocessing = parse_pipeline(
-        *get_parser_arguments_for_field(config, config_context_path, output_dir, "preprocessing")
-    )
-    pairing_function = parse_pairing_config(
-        *get_parser_arguments_for_field(config, config_context_path, output_dir, "pairing")
-    )
-    evaluation = parse_pipeline(*get_parser_arguments_for_field(config, config_context_path, output_dir, "comparing"))
+    preprocessing = parse_pipeline(pop_field(config, "preprocessing"), output_dir)
+    pairing_function = parse_pairing_config(pop_field(config, "pairing"), output_dir, config.context)
+    evaluation = parse_pipeline(pop_field(config, "comparing"), output_dir)
 
     return ScoreBasedSystem(output_dir.name, preprocessing, pairing_function, evaluation)
 
 
 @config_parser
-def two_level(config: dict[str, Any], config_context_path: list[str], output_dir: Path) -> LRSystem:
-    preprocessing = parse_pipeline(
-        *get_parser_arguments_for_field(config, config_context_path, output_dir, "preprocessing")
-    )
-    pairing_function = parse_pairing_config(
-        *get_parser_arguments_for_field(config, config_context_path, output_dir, "pairing")
-    )
-    postprocessing = parse_pipeline(
-        *get_parser_arguments_for_field(config, config_context_path, output_dir, "postprocessing")
-    )
-
-    n_trace_instances = pop_field(config_context_path, config, "n_trace_instances", validate=int)
-    n_ref_instances = pop_field(config_context_path, config, "n_ref_instances", validate=int)
+def two_level(config: ContextAwareDict, output_dir: Path) -> LRSystem:
+    preprocessing = parse_pipeline(pop_field(config, "preprocessing"), output_dir)
+    pairing_function = parse_pairing_config(pop_field(config, "pairing"), output_dir, config.context)
+    postprocessing = parse_pipeline(pop_field(config, "postprocessing"), output_dir)
+    n_trace_instances = pop_field(config, "n_trace_instances", validate=int)
+    n_ref_instances = pop_field(config, "n_ref_instances", validate=int)
 
     return TwoLevelSystem(
         output_dir.name,
@@ -104,28 +89,24 @@ def two_level(config: dict[str, Any], config_context_path: list[str], output_dir
     )
 
 
-def parse_lrsystem(config: dict[str, Any], config_context_path: list[str], output_dir: Path) -> LRSystem:
+def parse_lrsystem(config: ContextAwareDict, output_dir: Path) -> LRSystem:
     """Determine and initialise corresponding LR system from configuration values.
 
     LR systems are provided under the `architectures` key.
     """
-    if not config:
-        raise YamlParseError(config_context_path, "empty pipeline definition")
-
-    architecture = pop_field(config_context_path, config, "architecture")
+    architecture = pop_field(config, "architecture")
 
     try:
         parser = registry.get(architecture, search_path=["lrsystem_architectures"])
     except ComponentNotFoundError as e:
-        raise YamlParseError(config_context_path, f"{e}")
+        raise YamlParseError(config.context, f"{e}")
 
-    return parser.parse(config, config_context_path, output_dir)
+    return parser.parse(config, output_dir)
 
 
 def parse_augmented_lrsystem(
-    baseline_lrsystem_config: Configuration,
+    baseline_lrsystem_config: ContextAwareDict,
     hyperparameters: dict[str, HyperparameterOption],
-    context: list[str],
     output_dir: Path,
     dirname_prefix: str = "",
 ) -> LRSystem:
@@ -144,16 +125,12 @@ def parse_augmented_lrsystem(
     :return:
     """
     substitutions = dict(itertools.chain(*[opt.substitutions.items() for opt in hyperparameters.values()]))
-    try:
-        validate_substitution_paths(context, baseline_lrsystem_config, substitutions.keys())
-    except Exception as e:
-        LOG.warning(f"possible configuration error: {e}")
 
-    augmented_config = substitute_hyperparameters(baseline_lrsystem_config, substitutions)
     name = "__".join([f"{key}={value}" for key, value in hyperparameters.items()])
+    context = baseline_lrsystem_config.context + [f"substitution[{name}]"]
+    augmented_config = substitute_hyperparameters(baseline_lrsystem_config, substitutions, context)
     lrsystem = parse_lrsystem(
-        _expand(augmented_config),
-        context + [f"substitution[{name}]", "lr_system"],
+        augmented_config,
         output_dir / f"{dirname_prefix}{name}",
     )
     lrsystem.parameters = hyperparameters

--- a/lir/config/util.py
+++ b/lir/config/util.py
@@ -1,9 +1,8 @@
-from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 
-from lir.config.base import ConfigParser, pop_field
+from lir.config.base import ConfigParser, pop_field, ContextAwareDict
 from lir.config.transform import parse_module
 from lir.transform import Tee
 
@@ -11,13 +10,12 @@ from lir.transform import Tee
 class TeeParser(ConfigParser):
     def parse(
         self,
-        config: Mapping[str, Any],
-        config_context_path: list[str],
+        config: ContextAwareDict,
         output_dir: Path,
     ) -> Any:
         transformers = []
-        modules = pop_field(config_context_path, config, "modules")
+        modules = pop_field(config, "modules")
         for module_config in modules:
-            transformers.append(parse_module(module_config, config_context_path, output_dir))
+            transformers.append(parse_module(module_config, output_dir, module_config.context))
 
         return Tee(transformers)

--- a/lir/config/visualization.py
+++ b/lir/config/visualization.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from typing import Callable
 
-from confidence import Configuration
-
 from lir import registry
-from lir.config.base import GenericFunctionConfigParser, YamlParseError
+from lir.config.base import GenericFunctionConfigParser, YamlParseError, ContextAwareDict
 from lir.registry import ComponentNotFoundError
 
 
-def parse_visualizations(config: Configuration, context: list[str], output_path: Path) -> list[Callable]:
+def parse_visualizations(config: ContextAwareDict, output_path: Path) -> list[Callable]:
     """Prepare a list of functions to obtain the configured visualizations.
 
     Visualization functions must be available in the registry and accept three arguments:
@@ -24,9 +22,9 @@ def parse_visualizations(config: Configuration, context: list[str], output_path:
                 default_config_parser=GenericFunctionConfigParser,
                 search_path=["visualization"],
             )
-            func = parser.parse(config, context, output_path)
+            func = parser.parse(config, output_path)
             visualization_functions.append(func)
         except ComponentNotFoundError as e:
-            raise YamlParseError(context, str(e))
+            raise YamlParseError(config.context, str(e))
 
     return visualization_functions

--- a/lir/data/datasets/synthesized_normal_binary.py
+++ b/lir/data/datasets/synthesized_normal_binary.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 import numpy.random
 
-from lir.config.base import config_parser, pop_field
+from lir.config.base import config_parser, pop_field, ContextAwareDict
 from lir.data.models import DataSet
 
 
@@ -51,11 +51,11 @@ class SynthesizedNormalBinaryData(DataSet):
 
 
 @config_parser
-def synthesized_normal_binary(config: Mapping[str, Any], config_context_path: list[str], _: Path) -> DataSet:
+def synthesized_normal_binary(config: ContextAwareDict, _: Path) -> DataSet:
     """Set up (binary class) data source class to obtain normally distributed data from configuration."""
-    seed = pop_field(config_context_path, config, "seed")
-    h1 = pop_field(config_context_path, config, "h1")
-    h2 = pop_field(config_context_path, config, "h2")
+    seed = pop_field(config, "seed")
+    h1 = pop_field(config, "h1")
+    h2 = pop_field(config, "h2")
     data_classes = {
         1: SynthesizedNormalDataClass(**h1),
         0: SynthesizedNormalDataClass(**h2),

--- a/lir/data/datasets/synthesized_normal_multiclass.py
+++ b/lir/data/datasets/synthesized_normal_multiclass.py
@@ -4,6 +4,7 @@ from typing import Any, NamedTuple
 import numpy as np
 
 from lir.config.base import config_parser, pop_field
+from lir.config.substitution import ContextAwareDict
 from lir.data.models import DataSet
 
 
@@ -60,26 +61,24 @@ class SynthesizedNormalMulticlassData(DataSet):
 
 
 @config_parser
-def synthesized_normal_multiclass(config: dict[str, Any], config_context_path: list[str], _: Path) -> DataSet:
+def synthesized_normal_multiclass(config: ContextAwareDict, _: Path) -> DataSet:
     """Set up (multiple class) data source class to obtain normally distributed data from configuration."""
-    seed = pop_field(config_context_path, config, "seed", validate=int, required=False)
+    seed = pop_field(config, "seed", validate=int, required=False)
 
-    population = pop_field(config_context_path, config, "population")
-    population_size = pop_field(config_context_path + ["population"], population, "size", validate=int)
+    population = pop_field(config, "population")
+    population_size = pop_field(population, "size", validate=int)
     instances_per_source = pop_field(
-        config_context_path + ["population"],
         population,
         "instances_per_source",
         validate=int,
     )
 
-    dimensions_cfg = pop_field(config_context_path, config, "dimensions")
+    dimensions_cfg = pop_field(config, "dimensions")
     dimensions = []
-    for i, dim in enumerate(dimensions_cfg):
-        dimension_context = config_context_path + ["dimensions", str(i)]
-        mean = pop_field(dimension_context, dim, "mean", validate=float)
-        std = pop_field(dimension_context, dim, "std", validate=float)
-        error_std = pop_field(dimension_context, dim, "error_std", validate=float)
+    for dim in dimensions_cfg:
+        mean = pop_field(dim, "mean", validate=float)
+        std = pop_field(dim, "std", validate=float)
+        error_std = pop_field(dim, "error_std", validate=float)
         dimensions.append(SynthesizedDimension(mean, std, error_std))
 
     return SynthesizedNormalMulticlassData(

--- a/lir/optuna.py
+++ b/lir/optuna.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from confidence import Configuration
 import optuna
 
 from lir import compat
@@ -11,6 +10,7 @@ from lir.config.substitution import (
     Hyperparameter,
     FloatHyperparameter,
     HyperparameterOption,
+    ContextAwareDict,
 )
 from lir.data.models import DataStrategy
 from lir.experiment import Experiment
@@ -26,14 +26,12 @@ class OptunaExperiment(Experiment):
         aggregations: Sequence[Aggregation],
         visualization_functions: list[Callable],
         output_path: Path,
-        config_context_path: list[str],
-        baseline_config: Configuration,
+        baseline_config: ContextAwareDict,
         hyperparameters: list[Hyperparameter],
         n_trials: int,
         metric_function: Callable,
     ):
         super().__init__(name, data, aggregations, visualization_functions, output_path)
-        self._config_context_path = config_context_path
         self.baseline_config = baseline_config
         self.hyperparameters = hyperparameters
         self.n_trials = n_trials
@@ -67,7 +65,6 @@ class OptunaExperiment(Experiment):
         lrsystem = parse_augmented_lrsystem(
             self.baseline_config,
             assignments,
-            self._config_context_path + [str(trial.number)],
             self.output_path,
             dirname_prefix=f"{trial.number:03d}__",
         )

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1740691650d7347e6dda5bd268817d44ebb607b4897287f2c4dfe995edae48fa"
+content_hash = "sha256:a8777a38099f905f3e93a414dd2c329c577d21feae0675a41e1fa1c0cbc24168"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "Apache Software License 2.0"}
 dependencies = [
-    "confidence>=0.12",
+    "confidence>=0.17.1",
     "matplotlib>=3.5",
     "numpy>=1.22",
     "scikit-learn>=1.2",

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -84,6 +84,6 @@ from lir.config.substitution import parse_hyperparameter, _expand, Hyperparamete
     ],
 )
 def test_substitution(desc, yaml: str, expected_options: list[Any]):
-    cfg = _expand(confidence.loads(yaml))
-    param = parse_hyperparameter(cfg, [], Path("/"))
+    cfg = _expand([], confidence.loads(yaml))
+    param = parse_hyperparameter(cfg, Path("/"))
     assert param.options() == expected_options, desc


### PR DESCRIPTION
Config parsers need a dictionary (config content) and a context path. This PR combines the two values into a single class, ContextAwareDict. Makes code more readable.