### PR TITLE
Allow calculated LLR values to have an interval (optional)

### DIFF
--- a/lir/experiment.py
+++ b/lir/experiment.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence, Callable
 from pathlib import Path
@@ -18,14 +19,18 @@ def combine_results(llr_sets: list[LLRData]) -> LLRData:
     """Combine the results of the LLRData tuples into a single tuple."""
 
     llrs = [llr_data_tuple.llrs for llr_data_tuple in llr_sets]
-    intervals = [llr_data_tuple.intervals for llr_data_tuple in llr_sets if llr_data_tuple.intervals is not None]
-    labels = [llr_data_tuple.labels for llr_data_tuple in llr_sets if llr_data_tuple.labels is not None]
+    intervals = [llr_data_tuple.intervals for llr_data_tuple in llr_sets]
+    labels = [llr_data_tuple.labels for llr_data_tuple in llr_sets]
     meta_data = [llr_data_tuple.meta_data for llr_data_tuple in llr_sets]
 
     return LLRData(
         llrs=np.concatenate(llrs),
-        intervals=np.concatenate(intervals) if all(interval is not None for interval in intervals) else None,
-        labels=np.concatenate(labels) if all(label is not None for label in labels) else None,
+        intervals=(
+            np.concatenate(typing.cast(list[int], intervals))
+            if all(interval is not None for interval in intervals)
+            else None
+        ),
+        labels=np.concatenate(typing.cast(list[int], labels)) if all(label is not None for label in labels) else None,
         meta_data=np.concatenate(meta_data),
     )
 

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Mapping
+from typing import Any, Mapping, NamedTuple
 
 import numpy as np
 import sklearn.pipeline
@@ -65,6 +65,13 @@ class Pipeline(sklearn.pipeline.Pipeline):
         return super().transform(features)
 
 
+class LLRData(NamedTuple):
+    llrs: np.ndarray
+    meta_data: np.ndarray
+    intervals: np.ndarray | None = None  # 2 columns: low, high
+    labels: np.ndarray | None = None
+
+
 class LRSystem(ABC):
     """General representation of an LR system."""
 
@@ -81,9 +88,7 @@ class LRSystem(ABC):
         return self
 
     @abstractmethod
-    def apply(
-        self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the LR system on a set of instances, optionally with corresponding labels, and returns a set of LRs and
         their labels.

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -66,6 +66,12 @@ class Pipeline(sklearn.pipeline.Pipeline):
 
 
 class LLRData(NamedTuple):
+    """Representation of calculated LLR values.
+
+    The tuple contains same size numpy arrays of LLR values, corresponding
+    meta-data and optionally the corresponding interval values and labels.
+    """
+
     llrs: np.ndarray
     meta_data: np.ndarray
     intervals: np.ndarray | None = None  # 2 columns: low, high
@@ -90,11 +96,8 @@ class LRSystem(ABC):
     @abstractmethod
     def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
-        Applies the LR system on a set of instances, optionally with corresponding labels, and returns a set of LRs and
-        their labels.
-
-        The return value is a tuple of two numpy arrays of the same size, containing LRs and labels respectively. The
-        second array should be `None` if the input data are unlabeled.
+        Applies the LR system on a set of instances, optionally with corresponding labels, and returns a
+        representation of the calculated LLR data through the `LLRData` tuple.
         """
         raise NotImplementedError
 

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 from lir.transform.pairing import PairingMethod
 
 
@@ -35,9 +35,7 @@ class ScoreBasedSystem(LRSystem):
 
         return self
 
-    def apply(
-        self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a set
         of LLRs and their labels.
@@ -55,4 +53,8 @@ class ScoreBasedSystem(LRSystem):
 
         pair_llrs = self.evaluation_pipeline.transform(pair_features)
 
-        return pair_llrs, pair_labels, pair_meta
+        return LLRData(
+            llrs=pair_llrs,
+            labels=pair_labels,
+            meta_data=pair_meta,
+        )

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -37,8 +37,8 @@ class ScoreBasedSystem(LRSystem):
 
     def apply(self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
-        Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a set
-        of LLRs and their labels.
+        Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a
+        representation of the calculated LLR data through the `LLRData` tuple.
 
         The system takes instances as input, and calculates LLRs for pairs of instances. That means that there is a 2-1
         relation between input and output data.

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -22,7 +22,7 @@ class SpecificSourceSystem(LRSystem):
     def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
-        set of LLRs and their labels.
+        representation of the calculated LLR data through the `LLRData` tuple.
 
         The returned set of LLRs has the same order as the set of input instances, and the returned labels are unchanged
         from the input labels.

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 
 
 class SpecificSourceSystem(LRSystem):
@@ -19,9 +19,7 @@ class SpecificSourceSystem(LRSystem):
         self.pipeline.fit(instances, labels)
         return self
 
-    def apply(
-        self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
         set of LLRs and their labels.
@@ -30,4 +28,9 @@ class SpecificSourceSystem(LRSystem):
         from the input labels.
         """
         llrs = self.pipeline.transform(instances)
-        return llrs, labels, meta
+
+        return LLRData(
+            llrs=llrs,
+            labels=labels,
+            meta_data=meta,
+        )

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -1,5 +1,5 @@
 from typing import Any
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 
 import numpy as np
 import pandas as pd
@@ -448,7 +448,7 @@ class TwoLevelSystem(LRSystem):
 
         return self
 
-    def apply(self, features: Any, labels: Any, meta: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def apply(self, features: Any, labels: Any, meta: Any) -> LLRData:
         if labels is None:
             raise ValueError("pairing requires labels")
 
@@ -459,4 +459,8 @@ class TwoLevelSystem(LRSystem):
         pair_llrs = self.model.transform(*_split_pairs(pair_features, 1))
         pair_llrs = self.postprocessing_pipeline.transform(pair_llrs)
 
-        return pair_llrs, pair_labels, pair_meta
+        return LLRData(
+            llrs=pair_llrs,
+            labels=pair_labels,
+            meta_data=pair_meta,
+        )

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -449,6 +449,10 @@ class TwoLevelSystem(LRSystem):
         return self
 
     def apply(self, features: Any, labels: Any, meta: Any) -> LLRData:
+        """
+        Applies the two level LR system on a set of instances., optionally with corresponding labels,
+        and returns a representation of the calculated LLR data through the `LLRData` tuple.
+        """
         if labels is None:
             raise ValueError("pairing requires labels")
 

--- a/tests/lrsystems/test_specific_source.py
+++ b/tests/lrsystems/test_specific_source.py
@@ -10,7 +10,7 @@ from lir.data.datasets.synthesized_normal_binary import (
     SynthesizedNormalDataClass,
     SynthesizedNormalBinaryData,
 )
-from lir.lrsystems.lrsystems import Pipeline
+from lir.lrsystems.lrsystems import Pipeline, LLRData
 from lir.lrsystems.specific_source import SpecificSourceSystem
 
 
@@ -40,9 +40,13 @@ def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBina
         (features_test, labels_test, meta_test),
     ) = next(iter(data))
     specific_source_system.fit(features_train, labels_train, meta_train)
-    scores, labels, meta = specific_source_system.apply(
+
+    llr_data: LLRData = specific_source_system.apply(
         features_test, labels_test, meta_test
     )
+
+    scores = llr_data.llrs
+    labels = llr_data.labels
 
     golden_master_path = "tests/golden_master/test_specific_source_pipeline"
     if not os.path.exists(f"{golden_master_path}.npz"):

--- a/tests/lrsystems/test_two_level.py
+++ b/tests/lrsystems/test_two_level.py
@@ -6,6 +6,7 @@ from lir.data.datasets.synthesized_normal_multiclass import (
     SynthesizedNormalMulticlassData,
     SynthesizedDimension,
 )
+from lir.lrsystems.lrsystems import LLRData
 from lir.lrsystems.two_level import TwoLevelSystem
 from lir.transform.pairing import SourcePairing
 
@@ -31,7 +32,10 @@ def _calculate_cllr(
         "test_system", None, pairing, None, n_trace_instances=50, n_ref_instances=50
     )
     system.fit(*training_data)
-    pair_llrs, pair_labels, pair_meta = system.apply(*test_data)
+
+    llr_data: LLRData = system.apply(*test_data)
+    pair_llrs = llr_data.llrs
+    pair_labels = llr_data.labels
 
     return metrics.cllr(pair_llrs, pair_labels)
 


### PR DESCRIPTION
## Scope

Calculated LLR values are now represented by an `LLRData` tuple, which may or may not contain intervals (indicated by two columns; low and high percentile ranges respectively).