### PR TITLE
Introduce FeatureData to replace tuples

### DIFF
--- a/.github/workflows/check_test.yaml
+++ b/.github/workflows/check_test.yaml
@@ -30,7 +30,7 @@ jobs:
     needs: check
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']  # Check oldest and newest python version
+        python-version: ['3.11', '3.13']  # Check oldest and newest python version
     steps:
       - uses: actions/checkout@v5
       - uses: pdm-project/setup-pdm@v4

--- a/lir/data/datasets/alcohol_breath_analyser.py
+++ b/lir/data/datasets/alcohol_breath_analyser.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from lir.data.models import DataSet
+from lir.data.models import DataSet, LLRData
 
 
 class AlcoholBreathAnalyser(DataSet):
@@ -15,7 +15,7 @@ class AlcoholBreathAnalyser(DataSet):
     def __init__(self, ill_calibrated: bool = False):
         self.ill_calibrated = ill_calibrated
 
-    def get_instances(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_instances(self) -> LLRData:
         positive_lr = 1000 if self.ill_calibrated else 90
         lrs = np.concatenate(
             [
@@ -26,4 +26,4 @@ class AlcoholBreathAnalyser(DataSet):
             ]
         )
         y = np.concatenate([np.zeros(1000), np.ones(100)])
-        return np.log10(lrs), y, np.ones((len(y), 0))
+        return LLRData(features=np.log10(lrs), labels=y, meta=np.ones((len(y), 0)))  # type: ignore

--- a/lir/data/datasets/alcohol_breath_analyser.py
+++ b/lir/data/datasets/alcohol_breath_analyser.py
@@ -26,4 +26,4 @@ class AlcoholBreathAnalyser(DataSet):
             ]
         )
         y = np.concatenate([np.zeros(1000), np.ones(100)])
-        return LLRData(features=np.log10(lrs), labels=y, meta=np.ones((len(y), 0)))  # type: ignore
+        return LLRData(features=np.log10(lrs), labels=y)

--- a/lir/data/datasets/glass.py
+++ b/lir/data/datasets/glass.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from lir.data.io import RemoteResource
 from lir.data.models import DataSet, DataStrategy
+from lir.lrsystems.lrsystems import FeatureData
 
 
 class GlassData(DataSet, DataStrategy):
@@ -60,15 +61,18 @@ class GlassData(DataSet, DataStrategy):
         The data are returned as a tuple of features, labels, and metadata, similar to `get_instances()`.
         """
         training_data = self._load_data("training.csv")
+        training_data = FeatureData(
+            features=training_data[0], labels=training_data[1], meta=training_data[2]  # type: ignore
+        )
         test_features, test_labels, test_meta = zip(self._load_data("duplo.csv"), self._load_data("triplo.csv"))
-        test_data = (
-            np.concatenate(test_features),
-            np.concatenate(test_labels),
-            np.concatenate(test_meta),
+        test_data = FeatureData(
+            features=np.concatenate(test_features),
+            labels=np.concatenate(test_labels),
+            meta=np.concatenate(test_meta),  # type: ignore
         )
         return iter([(training_data, test_data)])
 
-    def get_instances(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_instances(self) -> FeatureData:
         """
         Returns `training.csv` data with three instances (replicates) per source, as a tuple of features, labels and
         metadata.
@@ -81,4 +85,5 @@ class GlassData(DataSet, DataStrategy):
 
         The meta values of an instance are a concatenation of the filename and a row number, e.g. "training.csv:22".
         """
-        return self._load_data("training.csv")
+        features, labels, meta = self._load_data("training.csv")
+        return FeatureData(features=features, labels=labels, meta=meta)  # type: ignore

--- a/lir/data/datasets/synthesized_normal_binary.py
+++ b/lir/data/datasets/synthesized_normal_binary.py
@@ -7,6 +7,7 @@ import numpy.random
 
 from lir.config.base import config_parser, pop_field, ContextAwareDict
 from lir.data.models import DataSet
+from lir.lrsystems.lrsystems import FeatureData
 
 
 class SynthesizedNormalDataClass:
@@ -35,7 +36,7 @@ class SynthesizedNormalBinaryData(DataSet):
         self.data_classes = data_classes
         self.seed = seed
 
-    def get_instances(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_instances(self) -> FeatureData:
         """
         Returns instances with randomly synthesized data and binary labels.
 
@@ -47,7 +48,7 @@ class SynthesizedNormalBinaryData(DataSet):
         values = [(data, [class_name] * data.shape[0]) for data, class_name in values]
         features = np.concatenate([data for data, _ in values])
         labels = np.concatenate([labels for _, labels in values])
-        return features, labels, np.array([]).reshape(labels.size, 0)
+        return FeatureData(features=features, labels=labels)
 
 
 @config_parser

--- a/lir/data/datasets/synthesized_normal_multiclass.py
+++ b/lir/data/datasets/synthesized_normal_multiclass.py
@@ -6,6 +6,7 @@ import numpy as np
 from lir.config.base import config_parser, pop_field
 from lir.config.substitution import ContextAwareDict
 from lir.data.models import DataSet
+from lir.lrsystems.lrsystems import FeatureData
 
 
 class SynthesizedDimension(NamedTuple):
@@ -43,7 +44,7 @@ class SynthesizedNormalMulticlassData(DataSet):
         measurements = np.concatenate([population] * self.sources_size) + measurement_error
         return measurements
 
-    def get_instances(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_instances(self) -> FeatureData:
         """
         Return instances with randomly synthesized data and multi-class labels.
 
@@ -55,9 +56,8 @@ class SynthesizedNormalMulticlassData(DataSet):
         measurements = [self._generate_dimension(rng, dim) for dim in self.dimensions]
         measurements = np.stack(measurements, axis=1)
         labels = np.concatenate([np.arange(self.population_size)] * self.sources_size)
-        meta = np.zeros((measurements.shape[0], 0))
 
-        return measurements, labels, meta
+        return FeatureData(features=measurements, labels=labels)
 
 
 @config_parser

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -152,6 +152,8 @@ def concatenate_instances(first: InstanceDataType, *others: InstanceDataType) ->
             values.append(getattr(instances, field))
         if isinstance(values[0], np.ndarray):
             data[field] = np.concatenate(values)
+        elif None in values:
+            data[field] = None
         else:
             data[field] = values
     return first.replace(**data)

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -63,15 +63,14 @@ class InstanceData(BaseModel, ABC):
         if type(self) is not type(other):
             return False
 
-        if self.model_extra.keys() != other.model_extra.keys():
+        if self.model_extra.keys() != other.model_extra.keys():  # type: ignore
             return False
 
         for field in self.all_fields:
-            if type(getattr(self, field)) != type(getattr(other, field)):
+            if type(getattr(self, field)) is not type(getattr(other, field)):
                 return False
 
         return True
-
 
     def __eq__(self, other: Any) -> bool:
         """
@@ -219,7 +218,9 @@ def concatenate_instances(first: InstanceDataType, *others: InstanceDataType) ->
             for instances in others:
                 other_value = getattr(instances, field)
                 if other_value != first_value:
-                    raise ValueError(f"unable to concatenate field `{field}`: value mismatch: {other_value} != {first_value}")
+                    raise ValueError(
+                        f"unable to concatenate field `{field}`: value mismatch: {other_value} != {first_value}"
+                    )
 
     return first.replace(**data)
 

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -64,9 +64,10 @@ class InstanceData(BaseModel, ABC):
     def has_labels(self) -> bool:
         return self.labels is not None
 
-    @abstractmethod
     def replace(self, **kwargs: Any) -> Self:
-        raise NotImplementedError
+        args = self.model_dump()
+        args.update(kwargs)
+        return type(self)(**args)  # type: ignore
 
 
 class FeatureData(InstanceData):
@@ -89,11 +90,6 @@ class FeatureData(InstanceData):
                 f"dimensions of labels and features do not match; {self.labels.shape[0]} != {self.features.shape[0]}"
             )
         return self
-
-    def replace(self, **kwargs: Any) -> Self:
-        args = self.model_dump()
-        args.update(kwargs)
-        return FeatureData(**args)  # type: ignore
 
 
 class LLRData(FeatureData):
@@ -127,11 +123,6 @@ class LLRData(FeatureData):
             return self.features[:, 1:]
         else:
             return None
-
-    def replace(self, **kwargs: Any) -> Self:
-        args = self.model_dump()
-        args.update(kwargs)
-        return LLRData(**args)  # type: ignore
 
     @model_validator(mode="after")
     def check_features_are_llrs(self) -> Self:

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -1,7 +1,169 @@
 from abc import abstractmethod, ABC
-from typing import Iterable
+from typing import Iterable, TypeVar, Self, Any, Annotated
 
 import numpy as np
+from pydantic import model_validator, AfterValidator, ConfigDict, BaseModel
+
+
+def _validate_labels(labels: np.ndarray | None) -> np.ndarray | None:
+    if labels is not None:
+        if not isinstance(labels, np.ndarray):
+            raise ValueError(f"labels must be None or np.ndarray; found: {type(labels)}")
+        if len(labels.shape) != 1:
+            raise ValueError(f"labels must be 1-dimensional; shape: {labels.shape}")
+
+    return labels
+
+
+class InstanceData(BaseModel, ABC):
+    """
+    Base class for data on instances.
+
+    Attributes:
+    - labels: an array of labels, a 1-dimensional array with one value per instance
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow", arbitrary_types_allowed=True)
+
+    labels: Annotated[np.ndarray | None, AfterValidator(_validate_labels)] = None
+
+    def __getitem__(self, indexes: np.ndarray) -> Self:
+        data = {}
+        for field in self.all_fields:
+            values = getattr(self, field)
+            if isinstance(values, np.ndarray):
+                data[field] = values[indexes]
+            else:
+                data[field] = values
+        return self.replace(**data)
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) is not type(other):
+            return False
+
+        for field in self.all_fields:
+            value = getattr(self, field)
+            other_value = getattr(other, field)
+            if isinstance(value, np.ndarray) and isinstance(other_value, np.ndarray):
+                if value.shape != other_value.shape or not np.all(value == other_value):
+                    return False
+            else:
+                if value != other_value:
+                    return False
+
+        return True
+
+    @property
+    def all_fields(self) -> list[str]:
+        all_fields = list(type(self).model_fields.keys())
+        if self.model_extra:
+            all_fields += list(self.model_extra.keys())
+        return all_fields
+
+    @property
+    def has_labels(self) -> bool:
+        return self.labels is not None
+
+    @abstractmethod
+    def replace(self, **kwargs: Any) -> Self:
+        raise NotImplementedError
+
+
+class FeatureData(InstanceData):
+    """
+    Data class for feature data.
+
+    Attributes:
+    - features: an array of instance features, with one row per instance
+    """
+
+    features: np.ndarray
+
+    def __len__(self) -> int:
+        return self.features.shape[0]
+
+    @model_validator(mode="after")
+    def check_matching_shapes(self) -> Self:
+        if self.labels is not None and self.labels.shape[0] != self.features.shape[0]:
+            raise ValueError(
+                f"dimensions of labels and features do not match; {self.labels.shape[0]} != {self.features.shape[0]}"
+            )
+        return self
+
+    def replace(self, **kwargs: Any) -> Self:
+        args = self.model_dump()
+        args.update(kwargs)
+        return FeatureData(**args)  # type: ignore
+
+
+class LLRData(FeatureData):
+    """
+    Representation of calculated LLR values.
+    """
+
+    @property
+    def llrs(self) -> np.ndarray:
+        """
+        :return: 1-dimensional numpy array of LLR values
+        """
+        if len(self.features.shape) == 1:
+            return self.features
+        else:
+            return self.features[:, 0]
+
+    @property
+    def has_intervals(self) -> bool:
+        """
+        :return: indicate whether the LLR's have intervals
+        """
+        return len(self.features.shape) == 2 and self.features.shape[1] == 3
+
+    @property
+    def llr_intervals(self) -> np.ndarray | None:
+        """
+        :return: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals
+        """
+        if self.has_intervals:
+            return self.features[:, 1:]
+        else:
+            return None
+
+    def replace(self, **kwargs: Any) -> Self:
+        args = self.model_dump()
+        args.update(kwargs)
+        return LLRData(**args)  # type: ignore
+
+    @model_validator(mode="after")
+    def check_features_are_llrs(self) -> Self:
+        if len(self.features.shape) > 2:
+            raise ValueError(f"features must have 1 or 2 dimensions; shape: {self.features.shape}")
+        if len(self.features.shape) == 2 and self.features.shape[1] != 3 and self.features.shape[1] != 1:
+            raise ValueError(
+                f"features must be 1-dimensional or 2-dimensional with 1 or 3 columns; shape: {self.features.shape}"
+            )
+
+        return self
+
+
+InstanceDataType = TypeVar("InstanceDataType", bound=InstanceData)
+FeatureDataType = TypeVar("FeatureDataType", bound=FeatureData)
+
+
+def concatenate_instances(first: InstanceDataType, *others: InstanceDataType) -> InstanceDataType:
+    """
+    Combine the results of the InstanceData objects.
+    """
+
+    data = {}
+    for field in first.all_fields:
+        values = [getattr(first, field)]
+        for instances in others:
+            values.append(getattr(instances, field))
+        if isinstance(values[0], np.ndarray):
+            data[field] = np.concatenate(values)
+        else:
+            data[field] = values
+    return first.replace(**data)
 
 
 class DataSet(ABC):
@@ -12,7 +174,7 @@ class DataSet(ABC):
     """
 
     @abstractmethod
-    def get_instances(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_instances(self) -> FeatureData:
         """
         Returns a tuple of instances and their meta data. For a data set of `n`
         instances, this function returns a tuple of:

--- a/lir/experiment.py
+++ b/lir/experiment.py
@@ -2,9 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence, Callable
 from pathlib import Path
-from typing import Any
 
-import numpy as np
 from tqdm import tqdm
 
 import lir
@@ -13,24 +11,6 @@ from lir.data.models import DataStrategy, concatenate_instances
 from lir.lrsystems.lrsystems import LRSystem, LLRData
 
 LOG = logging.getLogger(__name__)
-
-
-def np_concatenate_optional(optional_values: list[Any]) -> np.ndarray | None:
-    """Helper function to use `np.concatenate()` using collections with optional None values.
-
-    When a list may contain optional `None` values, it is not allowed (by type checking) to directly
-    call `np.concatenate()` on this list, even when explicitly checked that this list does not contain
-    `None` values.
-
-    This helper function either directly returns `None` if a collection contains a `None` value, or
-    it uses a workaround by using a list comprehension which filters out the `None` values (which are not
-    present anymore) to satisfy the type checker.
-    """
-    if None in optional_values:
-        return None
-
-    # Workaround for type checking optional None values
-    return np.concatenate([value for value in optional_values if value is not None])
 
 
 class Experiment(ABC):

--- a/lir/experiment.py
+++ b/lir/experiment.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 import lir
 from lir.aggregation import Aggregation
 from lir.data.models import DataStrategy, concatenate_instances
-from lir.lrsystems.lrsystems import LRSystem, LLRData, FeatureData
+from lir.lrsystems.lrsystems import LRSystem, LLRData
 
 LOG = logging.getLogger(__name__)
 
@@ -67,15 +67,9 @@ class Experiment(ABC):
 
         # Split the data into a train / test subset, according to the provided DataSetup. This could
         # for example be a simple binary split or a multiple fold cross validation split.
-        for (features_train, labels_train, meta_train), (
-            features_test,
-            labels_test,
-            meta_test,
-        ) in self.data:
-            lrsystem.fit(FeatureData(features=features_train, labels=labels_train, meta=meta_train))  # type: ignore
-            subset_llr_results: LLRData = lrsystem.apply(
-                FeatureData(features=features_test, labels=labels_test, meta=meta_test)  # type: ignore
-            )
+        for training_data, test_data in self.data:
+            lrsystem.fit(training_data)
+            subset_llr_results: LLRData = lrsystem.apply(test_data)
 
             # Store results (numpy arrays) into the placeholder lists
             llr_sets.append(subset_llr_results)

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Mapping
+from typing import Any, Mapping, NamedTuple
 
 import numpy as np
 import sklearn.pipeline
@@ -65,6 +65,13 @@ class Pipeline(sklearn.pipeline.Pipeline):
         return super().transform(features)
 
 
+class LLRData(NamedTuple):
+    llrs: np.ndarray
+    meta_data: np.ndarray
+    intervals: np.ndarray | None = None  # 2 columns: low, high
+    labels: np.ndarray | None = None
+
+
 class LRSystem(ABC):
     """General representation of an LR system."""
 
@@ -81,9 +88,7 @@ class LRSystem(ABC):
         return self
 
     @abstractmethod
-    def apply(
-        self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the LR system on a set of instances, optionally with corresponding labels, and returns a set of LRs and
         their labels.

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -66,6 +66,12 @@ class Pipeline(sklearn.pipeline.Pipeline):
 
 
 class LLRData(NamedTuple):
+    """Representation of calculated LLR values.
+
+    The tuple contains same size numpy arrays of LLR values, corresponding
+    meta-data and optionally the corresponding interval values and labels.
+    """
+
     llrs: np.ndarray
     meta_data: np.ndarray
     intervals: np.ndarray | None = None  # 2 columns: low, high
@@ -90,11 +96,8 @@ class LRSystem(ABC):
     @abstractmethod
     def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
-        Applies the LR system on a set of instances, optionally with corresponding labels, and returns a set of LRs and
-        their labels.
-
-        The return value is a tuple of two numpy arrays of the same size, containing LRs and labels respectively. The
-        second array should be `None` if the input data are unlabeled.
+        Applies the LR system on a set of instances, optionally with corresponding labels, and returns a
+        representation of the calculated LLR data through the `LLRData` tuple.
         """
         raise NotImplementedError
 

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 from lir.transform.pairing import PairingMethod
 
 
@@ -35,9 +35,7 @@ class ScoreBasedSystem(LRSystem):
 
         return self
 
-    def apply(
-        self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a set
         of LLRs and their labels.
@@ -55,4 +53,8 @@ class ScoreBasedSystem(LRSystem):
 
         pair_llrs = self.evaluation_pipeline.transform(pair_features)
 
-        return pair_llrs, pair_labels, pair_meta
+        return LLRData(
+            llrs=pair_llrs,
+            labels=pair_labels,
+            meta_data=pair_meta,
+        )

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -37,7 +37,7 @@ class ScoreBasedSystem(LRSystem):
         The system takes instances as input, and calculates LLRs for pairs of instances. That means that there is a 2-1
         relation between input and output data.
         """
-        if instances.has_labels:
+        if not instances.has_labels:
             raise ValueError("pairing requires labels")
 
         instances = self.preprocessing_pipeline.transform(instances)

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -37,8 +37,8 @@ class ScoreBasedSystem(LRSystem):
 
     def apply(self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
-        Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a set
-        of LLRs and their labels.
+        Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a
+        representation of the calculated LLR data through the `LLRData` tuple.
 
         The system takes instances as input, and calculates LLRs for pairs of instances. That means that there is a 2-1
         relation between input and output data.

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData, FeatureData
 from lir.transform.pairing import PairingMethod
 
 
@@ -25,17 +23,13 @@ class ScoreBasedSystem(LRSystem):
         self.pairing_function = pairing_function
         self.evaluation_pipeline = evaluation_pipeline or Pipeline([])
 
-    def fit(self, features: np.ndarray, labels: np.ndarray, meta: np.ndarray) -> "LRSystem":
-        features = self.preprocessing_pipeline.fit_transform(features, labels)
-
-        pair_features, pair_labels, pair_meta = self.pairing_function.pair(features, labels, meta, 1, 1)
-        pair_features = pair_features.transpose(0, 2, 1)
-
-        self.evaluation_pipeline.fit(pair_features, pair_labels)
-
+    def fit(self, instances: FeatureData) -> "LRSystem":
+        instances = self.preprocessing_pipeline.fit_transform(instances)
+        pairs = self.pairing_function.pair(instances, 1, 1)
+        self.evaluation_pipeline.fit(pairs)
         return self
 
-    def apply(self, features: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
+    def apply(self, instances: FeatureData) -> LLRData:
         """
         Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a
         representation of the calculated LLR data through the `LLRData` tuple.
@@ -43,18 +37,11 @@ class ScoreBasedSystem(LRSystem):
         The system takes instances as input, and calculates LLRs for pairs of instances. That means that there is a 2-1
         relation between input and output data.
         """
-        if labels is None:
+        if instances.has_labels:
             raise ValueError("pairing requires labels")
 
-        features = self.preprocessing_pipeline.transform(features)
+        instances = self.preprocessing_pipeline.transform(instances)
+        pairs = self.pairing_function.pair(instances, 1, 1)
+        pair_llrs = self.evaluation_pipeline.transform(pairs)
 
-        pair_features, pair_labels, pair_meta = self.pairing_function.pair(features, labels, meta, 1, 1)
-        pair_features = pair_features.transpose(0, 2, 1)
-
-        pair_llrs = self.evaluation_pipeline.transform(pair_features)
-
-        return LLRData(
-            llrs=pair_llrs,
-            labels=pair_labels,
-            meta_data=pair_meta,
-        )
+        return LLRData(**pair_llrs.model_dump())

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData, FeatureData
 
 
 class SpecificSourceSystem(LRSystem):
@@ -15,11 +13,11 @@ class SpecificSourceSystem(LRSystem):
         super().__init__(name)
         self.pipeline = pipeline
 
-    def fit(self, instances: np.ndarray, labels: np.ndarray, meta: np.ndarray) -> "LRSystem":
-        self.pipeline.fit(instances, labels)
+    def fit(self, instances: FeatureData) -> "LRSystem":
+        self.pipeline.fit(instances)
         return self
 
-    def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
+    def apply(self, instances: FeatureData) -> LLRData:
         """
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
         representation of the calculated LLR data through the `LLRData` tuple.
@@ -28,9 +26,4 @@ class SpecificSourceSystem(LRSystem):
         from the input labels.
         """
         llrs = self.pipeline.transform(instances)
-
-        return LLRData(
-            llrs=llrs,
-            labels=labels,
-            meta_data=meta,
-        )
+        return LLRData(**llrs.model_dump())

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -22,7 +22,7 @@ class SpecificSourceSystem(LRSystem):
     def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
-        set of LLRs and their labels.
+        representation of the calculated LLR data through the `LLRData` tuple.
 
         The returned set of LLRs has the same order as the set of input instances, and the returned labels are unchanged
         from the input labels.

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 
 
 class SpecificSourceSystem(LRSystem):
@@ -19,9 +19,7 @@ class SpecificSourceSystem(LRSystem):
         self.pipeline.fit(instances, labels)
         return self
 
-    def apply(
-        self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    def apply(self, instances: np.ndarray, labels: np.ndarray | None, meta: np.ndarray) -> LLRData:
         """
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
         set of LLRs and their labels.
@@ -30,4 +28,9 @@ class SpecificSourceSystem(LRSystem):
         from the input labels.
         """
         llrs = self.pipeline.transform(instances)
-        return llrs, labels, meta
+
+        return LLRData(
+            llrs=llrs,
+            labels=labels,
+            meta_data=meta,
+        )

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -1,5 +1,5 @@
 from typing import Any
-from lir.lrsystems.lrsystems import LRSystem, Pipeline
+from lir.lrsystems.lrsystems import LRSystem, Pipeline, LLRData
 
 import numpy as np
 import pandas as pd
@@ -448,7 +448,7 @@ class TwoLevelSystem(LRSystem):
 
         return self
 
-    def apply(self, features: Any, labels: Any, meta: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def apply(self, features: Any, labels: Any, meta: Any) -> LLRData:
         if labels is None:
             raise ValueError("pairing requires labels")
 
@@ -459,4 +459,8 @@ class TwoLevelSystem(LRSystem):
         pair_llrs = self.model.transform(*_split_pairs(pair_features, 1))
         pair_llrs = self.postprocessing_pipeline.transform(pair_llrs)
 
-        return pair_llrs, pair_labels, pair_meta
+        return LLRData(
+            llrs=pair_llrs,
+            labels=pair_labels,
+            meta_data=pair_meta,
+        )

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -449,6 +449,10 @@ class TwoLevelSystem(LRSystem):
         return self
 
     def apply(self, features: Any, labels: Any, meta: Any) -> LLRData:
+        """
+        Applies the two level LR system on a set of instances., optionally with corresponding labels,
+        and returns a representation of the calculated LLR data through the `LLRData` tuple.
+        """
         if labels is None:
             raise ValueError("pairing requires labels")
 

--- a/lir/optuna.py
+++ b/lir/optuna.py
@@ -78,8 +78,8 @@ class OptunaExperiment(Experiment):
             }
         )
 
-        llrs, labels = self._run_lrsystem(lrsystem)
-        return self.metric_function(llrs, labels)
+        llrs = self._run_lrsystem(lrsystem)
+        return self.metric_function(llrs.llrs, llrs.labels)
 
     def _generate_and_run(self) -> None:
         study = optuna.create_study()  # Create a new study.

--- a/lir/transform/distance.py
+++ b/lir/transform/distance.py
@@ -17,6 +17,6 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
 
     def transform(self, X):
         assert len(X.shape) == 3
-        assert X.shape[2] == 2
+        assert X.shape[1] == 2
 
-        return np.abs(X[:, :, 0] - X[:, :, 1])
+        return np.abs(X[:, 0, :] - X[:, 1, :])

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a8777a38099f905f3e93a414dd2c329c577d21feae0675a41e1fa1c0cbc24168"
+content_hash = "sha256:0663bfe887e67ab4c3f0448c78aa4d4ac6a134f8c4b2bfc48c4166dba7feca72"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -25,6 +25,20 @@ dependencies = [
 files = [
     {file = "alembic-1.17.0-py3-none-any.whl", hash = "sha256:80523bc437d41b35c5db7e525ad9d908f79de65c27d6a5a5eab6df348a352d99"},
     {file = "alembic-1.17.0.tar.gz", hash = "sha256:4652a0b3e19616b57d652b82bfa5e38bf5dbea0813eed971612671cb9e90c0fe"},
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+requires_python = ">=3.8"
+summary = "Reusable constraint types to use with typing.Annotated"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.0.0; python_version < \"3.9\"",
+]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
 [[package]]
@@ -1189,6 +1203,131 @@ files = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.3"
+requires_python = ">=3.9"
+summary = "Data validation using Python type hints"
+groups = ["default"]
+dependencies = [
+    "annotated-types>=0.6.0",
+    "pydantic-core==2.41.4",
+    "typing-extensions>=4.14.1",
+    "typing-inspection>=0.4.2",
+]
+files = [
+    {file = "pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf"},
+    {file = "pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74"},
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+requires_python = ">=3.9"
+summary = "Core functionality for Pydantic validation and serialization"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.14.1",
+]
+files = [
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2442d9a4d38f3411f22eb9dd0912b7cbf4b7d5b6c92c4173b75d3e1ccd84e36e"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30a9876226dda131a741afeab2702e2d127209bde3c65a2b8133f428bc5d006b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d55bbac04711e2980645af68b97d445cdbcce70e5216de444a6c4b6943ebcccd"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1d778fb7849a42d0ee5927ab0f7453bf9f85eef8887a546ec87db5ddb178945"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b65077a4693a98b90ec5ad8f203ad65802a1b9b6d4a7e48066925a7e1606706"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62637c769dee16eddb7686bf421be48dfc2fae93832c25e25bc7242e698361ba"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dfe3aa529c8f501babf6e502936b9e8d4698502b2cfab41e17a028d91b1ac7b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca2322da745bf2eeb581fc9ea3bbb31147702163ccbcbf12a3bb630e4bf05e1d"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e8cd3577c796be7231dcf80badcf2e0835a46665eaafd8ace124d886bab4d700"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1cae8851e174c83633f0833e90636832857297900133705ee158cf79d40f03e6"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a26d950449aae348afe1ac8be5525a00ae4235309b729ad4d3399623125b43c9"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win32.whl", hash = "sha256:0cf2a1f599efe57fa0051312774280ee0f650e11152325e41dfd3018ef2c1b57"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win_amd64.whl", hash = "sha256:a8c2e340d7e454dc3340d3d2e8f23558ebe78c98aa8f68851b04dcb7bc37abdc"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:28ff11666443a1a8cf2a044d6a545ebffa8382b5f7973f22c36109205e65dc80"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61760c3925d4633290292bad462e0f737b840508b4f722247d8729684f6539ae"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eae547b7315d055b0de2ec3965643b0ab82ad0106a7ffd29615ee9f266a02827"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ef9ee5471edd58d1fcce1c80ffc8783a650e3e3a193fe90d52e43bb4d87bff1f"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15dd504af121caaf2c95cb90c0ebf71603c53de98305621b94da0f967e572def"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a926768ea49a8af4d36abd6a8968b8790f7f76dd7cbd5a4c180db2b4ac9a3a2"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6916b9b7d134bff5440098a4deb80e4cb623e68974a87883299de9124126c2a8"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5cf90535979089df02e6f17ffd076f07237efa55b7343d98760bde8743c4b265"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7533c76fa647fade2d7ec75ac5cc079ab3f34879626dae5689b27790a6cf5a5c"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:37e516bca9264cbf29612539801ca3cd5d1be465f940417b002905e6ed79d38a"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0c19cb355224037c83642429b8ce261ae108e1c5fbf5c028bac63c77b0f8646e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win32.whl", hash = "sha256:09c2a60e55b357284b5f31f5ab275ba9f7f70b7525e18a132ec1f9160b4f1f03"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_amd64.whl", hash = "sha256:711156b6afb5cb1cb7c14a2cc2c4a8b4c717b69046f13c6b332d8a0a8f41ca3e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_arm64.whl", hash = "sha256:6cb9cf7e761f4f8a8589a45e49ed3c0d92d1d696a45a6feaee8c904b26efc2db"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1e5ab4fc177dd41536b3c32b2ea11380dd3d4619a385860621478ac2d25ceb00"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3d88d0054d3fa11ce936184896bed3c1c5441d6fa483b498fac6a5d0dd6f64a9"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b2a054a8725f05b4b6503357e0ac1c4e8234ad3b0c2ac130d6ffc66f0e170e2"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0d9db5a161c99375a0c68c058e227bee1d89303300802601d76a3d01f74e258"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6273ea2c8ffdac7b7fda2653c49682db815aebf4a89243a6feccf5e36c18c347"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:4c973add636efc61de22530b2ef83a65f39b6d6f656df97f678720e20de26caa"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b69d1973354758007f46cf2d44a4f3d0933f10b6dc9bf15cf1356e037f6f731a"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3619320641fd212aaf5997b6ca505e97540b7e16418f4a241f44cdf108ffb50d"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:491535d45cd7ad7e4a2af4a5169b0d07bebf1adfd164b0368da8aa41e19907a5"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:54d86c0cada6aba4ec4c047d0e348cbad7063b87ae0f005d9f8c9ad04d4a92a2"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca1124aced216b2500dc2609eade086d718e8249cb9696660ab447d50a758bd"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c9024169becccf0cb470ada03ee578d7348c119a0d42af3dcf9eda96e3a247c"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:26895a4268ae5a2849269f4991cdc97236e4b9c010e51137becf25182daac405"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:ca4df25762cf71308c446e33c9b1fdca2923a3f13de616e2a949f38bf21ff5a8"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5a28fcedd762349519276c36634e71853b4541079cab4acaaac60c4421827308"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c173ddcd86afd2535e2b695217e82191580663a1d1928239f877f5a1649ef39f"},
+    {file = "pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"},
+]
+
+[[package]]
 name = "pyflakes"
 version = "3.4.0"
 requires_python = ">=3.9"
@@ -1602,6 +1741,20 @@ groups = ["default", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+requires_python = ">=3.9"
+summary = "Runtime typing introspection tools"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.12.0",
+]
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,10 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:0663bfe887e67ab4c3f0448c78aa4d4ac6a134f8c4b2bfc48c4166dba7feca72"
+content_hash = "sha256:8eb9bcae8dc97ef862d6c07715b8a8aa8d52d01143881dd436b2ab6f9036b692"
 
 [[metadata.targets]]
-requires_python = ">=3.10"
+requires_python = ">=3.11"
 
 [[package]]
 name = "alembic"
@@ -311,21 +311,6 @@ groups = ["default"]
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.0"
-requires_python = ">=3.7"
-summary = "Backport of PEP 654 (exception groups)"
-groups = ["dev"]
-marker = "python_version < \"3.11\""
-dependencies = [
-    "typing-extensions>=4.6.0; python_version < \"3.13\"",
-]
-files = [
-    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
-    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
 ]
 
 [[package]]
@@ -1656,58 +1641,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.3.0"
-requires_python = ">=3.8"
-summary = "A lil' TOML parser"
-groups = ["default", "dev"]
-marker = "python_version < \"3.11\""
-files = [
-    {file = "tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45"},
-    {file = "tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba"},
-    {file = "tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf"},
-    {file = "tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441"},
-    {file = "tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845"},
-    {file = "tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c"},
-    {file = "tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456"},
-    {file = "tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be"},
-    {file = "tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac"},
-    {file = "tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22"},
-    {file = "tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f"},
-    {file = "tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52"},
-    {file = "tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8"},
-    {file = "tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6"},
-    {file = "tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876"},
-    {file = "tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878"},
-    {file = "tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b"},
-    {file = "tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae"},
-    {file = "tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b"},
-    {file = "tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf"},
-    {file = "tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f"},
-    {file = "tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05"},
-    {file = "tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606"},
-    {file = "tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999"},
-    {file = "tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e"},
-    {file = "tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3"},
-    {file = "tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc"},
-    {file = "tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0"},
-    {file = "tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879"},
-    {file = "tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005"},
-    {file = "tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463"},
-    {file = "tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8"},
-    {file = "tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77"},
-    {file = "tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf"},
-    {file = "tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530"},
-    {file = "tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b"},
-    {file = "tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67"},
-    {file = "tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f"},
-    {file = "tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0"},
-    {file = "tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba"},
-    {file = "tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b"},
-    {file = "tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549"},
-]
-
-[[package]]
 name = "tomlkit"
 version = "0.13.3"
 requires_python = ">=3.8"
@@ -1737,7 +1670,7 @@ name = "typing-extensions"
 version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["default", "dev"]
+groups = ["default"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 authors = [
     {name = "Netherlands Forensics Institute", email = "netherlandsforensicinstitute@users.noreply.github.com"},
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "Apache Software License 2.0"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "scipy>=1.13.1",
     "pandas>=2.3.2",
     "KDEpy>=1.1.12",
+    "pydantic>=2.12.3",
 ]
 
 [project.urls]

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -1,36 +1,38 @@
+from typing import Any, Self
+
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from lir.lrsystems.lrsystems import InstanceData, FeatureData, LLRData
+from lir.data.models import InstanceData, FeatureData, LLRData
+
+
+class _BareInstanceData(InstanceData):
+    def replace(self, **kwargs: Any) -> Self:
+        return self
 
 
 def test_instance_data():
-    InstanceData(labels=None)
-    InstanceData(labels=np.zeros((10,)))
-    InstanceData(labels=np.zeros((10,)), meta=np.zeros((10,)))  # type: ignore
-    InstanceData(labels=np.ones((10,)))
-    InstanceData(labels=np.concatenate([np.zeros((10,)), np.ones((10,))]))
+    _BareInstanceData(labels=None)
+    _BareInstanceData(labels=np.zeros((10,)))
+    _BareInstanceData(labels=np.zeros((10,)), meta=np.zeros((10,)))  # type: ignore
+    _BareInstanceData(labels=np.ones((10,)))
+    _BareInstanceData(labels=np.concatenate([np.zeros((10,)), np.ones((10,))]))
+
+    assert {"labels"} == set(_BareInstanceData(labels=None).all_fields)
+    assert {"labels", "meta"} == set(_BareInstanceData(labels=None, meta=1).all_fields)
 
     # illegal labels type
     with pytest.raises(ValidationError):
-        InstanceData(labels=1)  # type: ignore
+        _BareInstanceData(labels=1)  # type: ignore
 
     # illegal label dimensions
     with pytest.raises(ValidationError):
-        InstanceData(labels=np.ones((10, 1)))
-
-    # illegal label values
-    with pytest.raises(ValidationError):
-        InstanceData(labels=np.ones((10,)) * 2)
-
-    # illegal label values
-    with pytest.raises(ValidationError):
-        InstanceData(labels=np.array([0, 1, np.nan]))
+        _BareInstanceData(labels=np.ones((10, 1)))
 
     # illegal operation
     with pytest.raises(ValidationError):
-        instances = InstanceData(labels=np.array([0, 1]))
+        instances = _BareInstanceData(labels=np.array([0, 1]))
         instances.labels = np.array([1, 1])
 
 

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -8,8 +8,7 @@ from lir.data.models import InstanceData, FeatureData, LLRData
 
 
 class _BareInstanceData(InstanceData):
-    def replace(self, **kwargs: Any) -> Self:
-        return self
+    pass
 
 
 def test_instance_data():
@@ -19,8 +18,13 @@ def test_instance_data():
     _BareInstanceData(labels=np.ones((10,)))
     _BareInstanceData(labels=np.concatenate([np.zeros((10,)), np.ones((10,))]))
 
+    # test all_fields property
     assert {"labels"} == set(_BareInstanceData(labels=None).all_fields)
     assert {"labels", "meta"} == set(_BareInstanceData(labels=None, meta=1).all_fields)
+
+    # test slicing
+    assert np.all(_BareInstanceData(labels=np.arange(10))[:5].labels == np.arange(5))
+    assert _BareInstanceData(labels=np.arange(10))[8:9].labels == np.array([8])
 
     # illegal labels type
     with pytest.raises(ValidationError):

--- a/tests/lrsystems/test_specific_source.py
+++ b/tests/lrsystems/test_specific_source.py
@@ -10,7 +10,7 @@ from lir.data.datasets.synthesized_normal_binary import (
     SynthesizedNormalDataClass,
     SynthesizedNormalBinaryData,
 )
-from lir.lrsystems.lrsystems import Pipeline
+from lir.lrsystems.lrsystems import Pipeline, LLRData
 from lir.lrsystems.specific_source import SpecificSourceSystem
 
 
@@ -40,9 +40,13 @@ def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBina
         (features_test, labels_test, meta_test),
     ) = next(iter(data))
     specific_source_system.fit(features_train, labels_train, meta_train)
-    scores, labels, meta = specific_source_system.apply(
+
+    llr_data: LLRData = specific_source_system.apply(
         features_test, labels_test, meta_test
     )
+
+    scores = llr_data.llrs
+    labels = llr_data.labels
 
     golden_master_path = "tests/golden_master/test_specific_source_pipeline"
     if not os.path.exists(f"{golden_master_path}.npz"):

--- a/tests/lrsystems/test_specific_source.py
+++ b/tests/lrsystems/test_specific_source.py
@@ -10,7 +10,7 @@ from lir.data.datasets.synthesized_normal_binary import (
     SynthesizedNormalDataClass,
     SynthesizedNormalBinaryData,
 )
-from lir.lrsystems.lrsystems import Pipeline, LLRData
+from lir.lrsystems.lrsystems import Pipeline, LLRData, FeatureData
 from lir.lrsystems.specific_source import SpecificSourceSystem
 
 
@@ -35,17 +35,11 @@ def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBina
     pipeline = Pipeline(steps)
 
     specific_source_system = SpecificSourceSystem("test_system", pipeline)
-    (
-        (features_train, labels_train, meta_train),
-        (features_test, labels_test, meta_test),
-    ) = next(iter(data))
-    specific_source_system.fit(features_train, labels_train, meta_train)
+    data_train, data_test = next(iter(data))
+    specific_source_system.fit(data_train)
+    llr_data: LLRData = specific_source_system.apply(data_test)
 
-    llr_data: LLRData = specific_source_system.apply(
-        features_test, labels_test, meta_test
-    )
-
-    scores = llr_data.llrs
+    scores = llr_data.features
     labels = llr_data.labels
 
     golden_master_path = "tests/golden_master/test_specific_source_pipeline"
@@ -54,5 +48,5 @@ def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBina
         pytest.skip(f"Written {golden_master_path}, skipped test for this run.")
     else:
         expected = np.load(f"{golden_master_path}.npz")
-        assert np.array_equal(scores, expected["scores"])
-        assert np.array_equal(labels, expected["labels"])
+        assert np.all(scores == expected["scores"])
+        assert np.all(labels == expected["labels"])

--- a/tests/lrsystems/test_two_level.py
+++ b/tests/lrsystems/test_two_level.py
@@ -31,9 +31,8 @@ def _calculate_cllr(
     system = TwoLevelSystem(
         "test_system", None, pairing, None, n_trace_instances=50, n_ref_instances=50
     )
-    system.fit(*training_data)
-
-    llr_data: LLRData = system.apply(*test_data)
+    system.fit(training_data)
+    llr_data: LLRData = system.apply(test_data)
     pair_llrs = llr_data.llrs
     pair_labels = llr_data.labels
 

--- a/tests/lrsystems/test_two_level.py
+++ b/tests/lrsystems/test_two_level.py
@@ -6,6 +6,7 @@ from lir.data.datasets.synthesized_normal_multiclass import (
     SynthesizedNormalMulticlassData,
     SynthesizedDimension,
 )
+from lir.lrsystems.lrsystems import LLRData
 from lir.lrsystems.two_level import TwoLevelSystem
 from lir.transform.pairing import SourcePairing
 
@@ -31,7 +32,10 @@ def _calculate_cllr(
         "test_system", None, pairing, None, n_trace_instances=50, n_ref_instances=50
     )
     system.fit(*training_data)
-    pair_llrs, pair_labels, pair_meta = system.apply(*test_data)
+
+    llr_data: LLRData = system.apply(*test_data)
+    pair_llrs = llr_data.llrs
+    pair_labels = llr_data.labels
 
     return metrics.cllr(pair_llrs, pair_labels)
 

--- a/tests/test_data_strategies.py
+++ b/tests/test_data_strategies.py
@@ -13,14 +13,12 @@ def test_multiclass_train_test_split():
         population_size=100, sources_size=3, seed=0, dimensions=dimensions
     )
     strategy = MulticlassTrainTestSplit(data, test_size=0.5, seed=0)
-    features, labels, meta = data.get_instances()
+    instances = data.get_instances()
     for data_train, data_test in strategy:
-        labels_train = data_train[1]
-        labels_test = data_test[1]
-        assert len(np.unique(labels_train)) + len(np.unique(labels_test)) == len(
-            np.unique(labels)
+        assert len(np.unique(data_train.labels)) + len(np.unique(data_test.labels)) == len(
+            np.unique(instances.labels)
         )
-        assert len(labels_train) + len(labels_test) == len(labels)
+        assert len(data_train.labels) + len(data_test.labels) == len(instances.labels)
 
 
 def test_multiclass_train_test_split_seed():
@@ -38,12 +36,12 @@ def test_multiclass_train_test_split_seed():
     strategies = [MulticlassTrainTestSplit(data, test_size=0.5, seed=0)] * 2
     for strategy in strategies:
         for data_train, data_test in strategy:
-            assert np.all(data_train[0] == ref_train[0])
-            assert np.all(data_test[0] == ref_test[0])
+            assert data_train == ref_train
+            assert data_test == ref_test
 
     # test:
     # - another MulticlassTrainTestSplit instance with another seed should yield different results
     strategy = MulticlassTrainTestSplit(data, test_size=0.5, seed=1)
     for data_train, data_test in strategy:
-        assert not np.all(data_train[0] == ref_train[0])
-        assert not np.all(data_test[0] == ref_test[0])
+        assert not data_train == ref_train
+        assert not data_test == ref_test

--- a/tests/test_ece.py
+++ b/tests/test_ece.py
@@ -17,8 +17,9 @@ class TestECE(unittest.TestCase):
 
 
     def test_cllr(self):
+        breath = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
         data = [
-            AlcoholBreathAnalyser(ill_calibrated=True).get_instances()[:2],
+            (breath.features, breath.labels),
             (np.array([-1, 1, np.inf]), np.array([0, 1, 1])),
             (np.array([-1, 1, np.inf]), np.array([0, 1, 0])),
             (np.array([-1, 1, -np.inf]), np.array([0, 1, 1])),

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -12,8 +12,8 @@ from lir.util import Xn_to_Xy, probability_to_logodds, logodds_to_odds
 
 class TestElub(unittest.TestCase):
     def test_breath(self):
-        llrs, y, _ = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
-        bounds = bayeserror.elub(logodds_to_odds(llrs), y, add_misleading=1)
+        data = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
+        bounds = bayeserror.elub(logodds_to_odds(data.llrs), data.labels, add_misleading=1)
         np.testing.assert_almost_equal((0.11051160265422605, 80.42823031359497), bounds)
 
     def test_extreme_smallset(self):

--- a/tests/test_invariance_bounds.py
+++ b/tests/test_invariance_bounds.py
@@ -7,14 +7,15 @@ from sklearn.pipeline import Pipeline
 from lir.algorithms import invariance_bounds
 from lir.algorithms.invariance_bounds import IVBounder
 from lir.data.datasets.alcohol_breath_analyser import AlcoholBreathAnalyser
+from lir.data.models import LLRData
 from lir.transform import BinaryClassifierTransformer, FunctionTransformer
 from lir.util import Xn_to_Xy, probability_to_logodds, logodds_to_odds
 
 
 class TestBounding(unittest.TestCase):
     def test_breath(self):
-        llrs, y, meta = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
-        bounds = invariance_bounds.calculate_invariance_bounds(logodds_to_odds(llrs), y)
+        llrs = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
+        bounds = invariance_bounds.calculate_invariance_bounds(logodds_to_odds(llrs.llrs), llrs.labels)
         np.testing.assert_almost_equal((0.1052741, 85.3731634), bounds[:2])
 
     def test_extreme_smallset(self):

--- a/tests/test_lrsystem.py
+++ b/tests/test_lrsystem.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from lir.lrsystems.lrsystems import InstanceData, FeatureData, LLRData
+
+
+def test_instance_data():
+    InstanceData(labels=None)
+    InstanceData(labels=np.zeros((10,)))
+    InstanceData(labels=np.zeros((10,)), meta=np.zeros((10,)))  # type: ignore
+    InstanceData(labels=np.ones((10,)))
+    InstanceData(labels=np.concatenate([np.zeros((10,)), np.ones((10,))]))
+
+    # illegal labels type
+    with pytest.raises(ValidationError):
+        InstanceData(labels=1)  # type: ignore
+
+    # illegal label dimensions
+    with pytest.raises(ValidationError):
+        InstanceData(labels=np.ones((10, 1)))
+
+    # illegal label values
+    with pytest.raises(ValidationError):
+        InstanceData(labels=np.ones((10,)) * 2)
+
+    # illegal label values
+    with pytest.raises(ValidationError):
+        InstanceData(labels=np.array([0, 1, np.nan]))
+
+    # illegal operation
+    with pytest.raises(ValidationError):
+        instances = InstanceData(labels=np.array([0, 1]))
+        instances.labels = np.array([1, 1])
+
+
+def test_feature_data():
+    FeatureData(features=np.ones((10, 2)), labels=None)
+    FeatureData(features=np.ones((10, 2)), labels=np.ones((10,)))
+    with pytest.raises(ValidationError):
+        FeatureData(features=np.ones((10, 2)), labels=np.ones((11,)))
+
+    # illegal operation
+    with pytest.raises(ValidationError):
+        instances = FeatureData(features=np.ones((10, 2)), labels=np.ones((10,)))
+        instances.features = np.ones((10, 2))
+
+
+def test_llr_data():
+    LLRData(features=np.ones((10,)))
+    LLRData(features=np.ones((10, 1)))
+    LLRData(features=np.ones((10, 3)))
+    LLRData(features=np.ones((10,)), labels=np.ones(10))
+
+    with pytest.raises(ValidationError):
+        LLRData(features=np.ones((10, 2)))
+
+    with pytest.raises(ValidationError):
+        LLRData(features=np.ones((10, 4)))
+
+    with pytest.raises(ValidationError):
+        LLRData(features=np.ones((10, 3, 1)))
+
+    with pytest.raises(ValidationError):
+        LLRData(features=np.ones((10,)), labels=np.ones(11))
+
+    llr_values = np.arange(30).reshape(10, 3)
+    assert np.all(LLRData(features=llr_values).llrs == llr_values[:, 0])
+    assert np.all(LLRData(features=llr_values[:, 0]).llrs == llr_values[:, 0])
+    assert np.all(LLRData(features=llr_values[:, 0:1]).llrs == llr_values[:, 0])
+    assert np.all(LLRData(features=llr_values).llr_intervals == llr_values[:, 1:3])

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -18,23 +18,25 @@ def test_instance_pairing_seed():
         dimensions, population_size=100, sources_size=2, seed=0
     )
 
-    pairing0 = InstancePairing()
-    pairing1 = InstancePairing()
+    pairing0 = InstancePairing(seed=1)
+    pairing1 = InstancePairing(seed=1)
+    instances = data.get_instances()
+    instances_tuple = instances.features, instances.labels, np.ones((instances.labels.shape[0], 0))
     for values in zip(
-        pairing0.pair(*data.get_instances()), pairing1.pair(*data.get_instances())
+        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple)
     ):
-        np.all(values[0] == values[1])
+        assert np.all(values[0] == values[1])
 
-    pairing0 = InstancePairing(ratio_limit=1)
-    pairing1 = InstancePairing(ratio_limit=1)
+    pairing0 = InstancePairing(seed=1, ratio_limit=1)
+    pairing1 = InstancePairing(seed=1, ratio_limit=1)
     for values in zip(
-        pairing0.pair(*data.get_instances()), pairing0.pair(*data.get_instances())
+        pairing0._pair_arrays(*instances_tuple), pairing0._pair_arrays(*instances_tuple)
     ):
-        np.all(values[0] == values[1])
+        assert np.all(values[0] == values[1])
     for values in zip(
-        pairing0.pair(*data.get_instances()), pairing1.pair(*data.get_instances())
+        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple)
     ):
-        np.all(values[0] == values[1])
+        assert np.all(values[0] == values[1])
 
 
 @pytest.mark.parametrize(
@@ -190,7 +192,7 @@ def test_source_level_pairing(
     n_trace_instances: int,
     n_ref_instances: int,
 ):
-    pair_features, pair_labels, pair_meta = SourcePairing().pair(
+    pair_features, pair_labels, pair_meta = SourcePairing()._pair_arrays(
         features, labels, features, n_trace_instances, n_ref_instances
     )
     assert len(pair_labels) == n_pairs_expected

--- a/tests/test_synthesized_data.py
+++ b/tests/test_synthesized_data.py
@@ -16,11 +16,7 @@ def test_binary_data():
         1: SynthesizedNormalDataClass(1, 1, 100),
     }
     data = SynthesizedNormalBinaryData(data_spec, seed=0)
-    for values in zip(
-        data.get_instances(),
-        SynthesizedNormalBinaryData(data_spec, seed=0).get_instances(),
-    ):
-        np.all(values[0] == values[1])
+    assert data.get_instances() == SynthesizedNormalBinaryData(data_spec, seed=0).get_instances()
 
 
 def test_multiclass_data():
@@ -33,8 +29,5 @@ def test_multiclass_data():
     data1 = SynthesizedNormalMulticlassData(
         dimensions=dimensions, population_size=100, sources_size=2, seed=0
     )
-    for values in zip(data0.get_instances(), data1.get_instances()):
-        np.all(values[0] == values[1])
-
-    for values in zip(data0.get_instances(), data0.get_instances()):
-        np.all(values[0] == values[1])
+    assert data0.get_instances() == data1.get_instances()
+    assert data0.get_instances() == data0.get_instances()


### PR DESCRIPTION
Vervangt de tuple (features, labels, meta) door een dataclass `FeatureData`, en de subclass `LLRData` voor het geval de features LLRs zijn. Hierdoor vervalt de noodzaak voor `meta`. Dit raakt de `DataSet` en `LRSystem` subclasses. Het ligt voor de hand om dit ook in de transformers door te voeren, maar die blijven in deze PR nog buiten schot.