### PR TITLE
Introduce PairData, dedicated to instance pairs, as a subclass of FeatureData

### DIFF
--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -441,7 +441,7 @@ class TwoLevelSystem(LRSystem):
         self.model.fit_on_unpaired_instances(instances.features, instances.labels)
 
         pairs = self.pairing_function.pair(instances)
-        pair_llrs = pairs.replace(features=self.model.transform(*_split_pairs(pairs.features, 1)))
+        pair_llrs = pairs.replace_as(LLRData, features=self.model.transform(pairs.features_trace, pairs.features_ref))
         self.postprocessing_pipeline.fit(pair_llrs)
 
         return self
@@ -457,9 +457,7 @@ class TwoLevelSystem(LRSystem):
         instances = self.preprocessing_pipeline.transform(instances)
 
         pairs = self.pairing_function.pair(instances)
-        pair_llrs = LLRData(
-            **pairs.replace(features=self.model.transform(*_split_pairs(pairs.features, 1))).model_dump()
-        )
+        pair_llrs = pairs.replace_as(LLRData, features=self.model.transform(pairs.features_trace, pairs.features_ref))
         pair_llrs = self.postprocessing_pipeline.transform(pair_llrs)
 
         return pair_llrs

--- a/lir/transform/pairing.py
+++ b/lir/transform/pairing.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import numpy as np
 
+from lir.data.models import PairedFeatureData
 from lir.lrsystems.lrsystems import FeatureData
 
 
@@ -19,7 +20,7 @@ class PairingMethod(ABC):
         instances: FeatureData,
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
-    ) -> FeatureData:
+    ) -> PairedFeatureData:
         """
         Takes instances as input, and returns pairs.
 
@@ -51,12 +52,18 @@ class LegacyPairingMethod(ABC):
         instances: FeatureData,
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
-    ) -> FeatureData:
+    ) -> PairedFeatureData:
         meta = instances.meta if hasattr(instances, "meta") else np.zeros((instances.features.shape[0], 0))
         pair_features, pair_labels, pair_meta = self._pair_arrays(
             instances.features, instances.labels, meta, n_trace_instances, n_ref_instances
         )
-        pairs = FeatureData(features=pair_features, labels=pair_labels, meta=pair_meta)  # type: ignore
+        pairs = PairedFeatureData(
+            features=pair_features,
+            labels=pair_labels,
+            n_trace_instances=n_trace_instances,
+            n_ref_instances=n_ref_instances,
+            meta=pair_meta,  # type: ignore
+        )
         return pairs
 
     @abstractmethod

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from lir.data.models import InstanceData, FeatureData, LLRData, concatenate_instances
+from lir.data.models import InstanceData, FeatureData, LLRData, concatenate_instances, PairedFeatureData
 
 
 class BareData(InstanceData):
@@ -80,6 +80,23 @@ def test_concatenate():
 
     with pytest.raises(ValueError):
         concatenate_instances(FeatureData(features=np.ones((10, 2)), extra1=[1, 2]), FeatureData(features=np.ones((10, 2)), extra1=[2, 1]))
+
+
+def test_pair_data():
+    """
+    Check consistency and validation mechanism of `PairedFeatureData`.
+    """
+    PairedFeatureData(features=np.ones((10, 9, 1)), n_trace_instances=4, n_ref_instances=5)
+
+    with pytest.raises(ValueError):
+        PairedFeatureData(features=np.ones((10, 9)), n_trace_instances=4, n_ref_instances=5)
+
+    with pytest.raises(ValueError):
+        PairedFeatureData(features=np.ones((10, 9, 1)), n_trace_instances=4, n_ref_instances=4)
+
+    assert PairedFeatureData(features=np.ones((10, 9, 1)), n_trace_instances=4, n_ref_instances=5).features_trace.shape == (10, 4, 1)
+    assert PairedFeatureData(features=np.ones((10, 9, 1)), n_trace_instances=4, n_ref_instances=5).features_ref.shape == (10, 5, 1)
+    assert PairedFeatureData(features=np.ones((10, 9, 3, 4)), n_trace_instances=4, n_ref_instances=5).features_ref.shape == (10, 5, 3, 4)
 
 
 def test_llr_data():


### PR DESCRIPTION
The `PairData` class makes explicit that a feature array contains features of paired instances, and the semantics of the feature array itself. It has information on the number of instances involved, that otherwise has to be derived from context information, and it has attributes to get the trace/reference side of the pairs.