### PR TITLE
Allow dynamic configuration of H1/H2 colors in e.g. pav plots

### DIFF
--- a/lir/config/visualization.py
+++ b/lir/config/visualization.py
@@ -1,30 +1,59 @@
+from collections import ChainMap
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Any
 
 from lir import registry
 from lir.config.base import GenericFunctionConfigParser, YamlParseError, ContextAwareDict
 from lir.registry import ComponentNotFoundError
+from functools import partial
+from collections.abc import Mapping
 
 
-def parse_visualizations(config: ContextAwareDict, output_path: Path) -> list[Callable]:
+def parse_visualizations(config: ContextAwareDict, output_path: Path) -> list[Callable[..., Any]]:
     """Prepare a list of functions to obtain the configured visualizations.
 
     Visualization functions must be available in the registry and accept three arguments:
        - output_dir: Path, the directory where output files can be created
        - lrs: np.ndarray, a list of lrs
        - labels: np.ndarray, a list of labels corresponding to the lrs
+
+    Additionally, any provided extra options are parsed and passed as parameters to the
+    corresponding visualization function. In the example below, the keyword arguments `h1_color`
+    and `h2_color` will be passed to the corresponding function to generate `pav` plots.
+
+    ```yaml
+    visualization:
+      - pav:
+         - h1_color: yellow
+         - h2_color: green
+    ```
     """
-    visualization_functions = []
-    for visualization_type in config:
+    visualization_functions: list[Callable[..., Any]] = []
+
+    # Collect the visualizations declared in the configuration as key value pairs of name/parameters
+    defined_visualizations: dict[str, dict] = {}
+
+    for visualization in config:
+        # Collect visualization types and extra options, or use empty dictionary if no options were provided
+        visualization_with_params = visualization if isinstance(visualization, Mapping) else {visualization: {}}
+        defined_visualizations.update(visualization_with_params)
+
+    for visualization_type, extra_options in defined_visualizations.items():
         try:
             parser = registry.get(
                 visualization_type,
                 default_config_parser=GenericFunctionConfigParser,
                 search_path=["visualization"],
             )
-            func = parser.parse(config, output_path)
-            visualization_functions.append(func)
         except ComponentNotFoundError as e:
             raise YamlParseError(config.context, str(e))
+
+        visualization_fn = parser.parse(ContextAwareDict(config.context + [visualization_type]), output_path)
+
+        # The `extra_options` are represented in a `ContextAwareList`, which needs to be cast to the
+        # corresponding dictionary to provide the `**kwargs` to the visualization function.
+        extra_parameters = extra_options if isinstance(extra_options, dict) else dict(ChainMap(*extra_options))
+
+        visualization_functions.append(partial(visualization_fn, **extra_parameters))
 
     return visualization_functions

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -28,9 +28,6 @@ plt.get_ylim = lambda: plt.gca().get_ylim()
 plt.set_xticks = plt.xticks
 plt.set_yticks = plt.yticks
 
-H1_COLOR = "red"
-H2_COLOR = "blue"
-
 
 class Canvas:
     def __init__(self, ax: Axis):
@@ -114,6 +111,8 @@ def pav(
     add_misleading: int = 0,
     show_scatter: bool = True,
     ax: Axes = plt,
+    h1_color: str = "red",
+    h2_color: str = "blue",
 ) -> None:
     """
     Generates a plot of pre- versus post-calibrated LRs using Pool Adjacent
@@ -131,6 +130,10 @@ def pav(
         If True, show individual LRs (default: `True`)
     ax : pyplot axes object
         defaults to `matplotlib.pyplot`
+    h1_color : color
+        color for H1 points in scatter plot (default: 'red')
+    h2_color : color
+        color for H2 points in scatter plot (default: 'blue')
     ----------
     """
     pav = IsotonicCalibrator(add_misleading=add_misleading)
@@ -204,7 +207,7 @@ def pav(
         ax.set_yticks(ticks_y, tick_labels_y)
         ax.set_xticks(ticks_x, tick_labels_x)
 
-        color = [H1_COLOR if i > 0 else H2_COLOR for i in y_inf]
+        color = [h1_color if i > 0 else h2_color for i in y_inf]
         ax.scatter(x_inf, y_inf, color=color, marker="|")
 
     ax.axis(xrange + yrange)
@@ -222,8 +225,8 @@ def pav(
         n_h1 = np.count_nonzero(y)
         n_h2 = len(y) - n_h1
 
-        ax.scatter(h1_llrs, h1_pav, facecolors=H1_COLOR, marker=2, linewidths=1, alpha=0.5, label=f"H1 (n={n_h1})")
-        ax.scatter(h2_llrs, h2_pav, facecolors=H2_COLOR, marker=3, linewidths=1, alpha=0.5, label=f"H2 (n={n_h2})")
+        ax.scatter(h1_llrs, h1_pav, facecolors=h1_color, marker=2, linewidths=1, alpha=0.5, label=f"H1 (n={n_h1})")
+        ax.scatter(h2_llrs, h2_pav, facecolors=h2_color, marker=3, linewidths=1, alpha=0.5, label=f"H2 (n={n_h2})")
 
         # scatter plot of measured lrs
 

--- a/lir/visualization.py
+++ b/lir/visualization.py
@@ -1,29 +1,30 @@
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
 from lir.plotting import savefig
 
 
-def pav(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def pav(base_path: Path, llrs: np.ndarray, labels: np.ndarray, **kwargs: Any) -> None:
     """Helper function to generate and save a PAV-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / "pav.png"
     with savefig(str(path)) as fig:
-        fig.pav(llrs, labels)
+        fig.pav(llrs, labels, **kwargs)
 
 
-def ece(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def ece(base_path: Path, llrs: np.ndarray, labels: np.ndarray, **kwargs: Any) -> None:
     """Helper function to generate and save an ECE-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / "ece.png"
     with savefig(str(path)) as fig:
-        fig.ece(llrs, labels)
+        fig.ece(llrs, labels, **kwargs)
 
 
-def lr_histogram(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def lr_histogram(base_path: Path, llrs: np.ndarray, labels: np.ndarray, **kwargs: Any) -> None:
     """Helper function to generate and save an histogram-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / "histogram.png"
     with savefig(str(path)) as fig:
-        fig.lr_histogram(llrs, labels)
+        fig.lr_histogram(llrs, labels, **kwargs)

--- a/tests/config/test_visualization.py
+++ b/tests/config/test_visualization.py
@@ -1,0 +1,75 @@
+import yaml
+import pytest
+
+from lir.config.base import ContextAwareDict, ContextAwareList, pop_field
+from lir.config.visualization import parse_visualizations
+
+
+def _yaml_to_context_aware_config(config_dict: dict) -> ContextAwareDict:
+    """Helper function to produce a ContextAwareDict from a regular dict."""
+    config_key, config_values = next(iter(config_dict.items()))
+
+    context_dict = ContextAwareDict(context=[])
+    context_list = ContextAwareList(context=[])
+
+    context_list.extend(config_values)
+
+    context_dict.update({
+        config_key: context_list
+    })
+
+    return context_dict
+
+
+@pytest.mark.parametrize('yaml_config', [
+"""
+visualization:
+    - pav:
+        h1_color: green
+        h2_color: blue
+    - ece
+""",
+"""
+visualization:
+    - pav:
+        - h1_color: green
+        - h2_color: blue
+    - ece
+""",
+"""
+visualization:
+    - pav:
+        - h1_color: green
+          h2_color: blue
+    - ece
+""",
+])
+def test_parse_extra_visualization_options(yaml_config: str):
+    """Check that extra provided visualization options are handled correctly."""
+    config = yaml.safe_load(yaml_config)
+    output_path = 'tests/output/config'  # not used in actual test
+
+    # Given that we provide the appropriate configuration
+    context_aware_config = _yaml_to_context_aware_config(config)
+
+    # When we collect the parse functions for our visualizations
+    visualization_functions = parse_visualizations(
+        pop_field(context_aware_config, 'visualization'),
+        output_path=output_path,
+    )
+
+    assert len(visualization_functions) == 2
+
+    pav_plot_function = visualization_functions[0]
+    assert pav_plot_function.func.__name__ == 'pav'
+
+    ece_function = visualization_functions[1]
+    assert ece_function.func.__name__ == 'ece'
+
+
+    # We expected both keyword arguments available
+    assert pav_plot_function.keywords['h1_color'] == 'green'
+    assert pav_plot_function.keywords['h2_color'] == 'blue'
+
+    # No keywords have been specified for the 'ece' function
+    assert len(ece_function.keywords) == 0


### PR DESCRIPTION
This patch allows the colors of H1 and H2 datapoints in generated plots to be configured dynamically in the YAML configuration as follows:


```yaml
visualization:
    - pav:
        h1_color: green
        h2_color: blue
```

or

```yaml
visualization:
    - pav:
        - h1_color: green
        - h2_color: blue
```

or

```yaml
visualization:
    - pav:
        - h1_color: green
          h2_color: blue
```