### PR TITLE
Introduce ruff

### DIFF
--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -1,7 +1,9 @@
 import csv
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Mapping, Callable, Any, OrderedDict, IO
+from typing import IO, Any
 
 import numpy as np
 
@@ -18,7 +20,7 @@ class Aggregation(ABC):
         """
         raise NotImplementedError
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: B027
         """
         Finalize the aggregation; no more results will come in.
 
@@ -42,7 +44,7 @@ class WriteMetricsToCsv(Aggregation):
         # Record column header names only once to the CSV
         if self._writer is None:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            self._file = open(self.path, "w")
+            self._file = open(self.path, 'w')  # noqa: SIM115
             self._writer = csv.DictWriter(self._file, fieldnames=results.keys())
             self._writer.writeheader()
 

--- a/lir/algorithms/bayeserror.py
+++ b/lir/algorithms/bayeserror.py
@@ -34,10 +34,10 @@ def plot_nbe(
 
     ax.plot(log_lr_threshold, np.log10(eu_neutral / eu_system))
 
-    ax.set_xlabel("log$_{10}$(threshold LR)")
-    ax.set_ylabel("log$_{10}$(expected utility ratio)")
+    ax.set_xlabel('log$_{10}$(threshold LR)')
+    ax.set_ylabel('log$_{10}$(expected utility ratio)')
     ax.set_xlim(log_lr_threshold_range)
-    ax.grid(True, linestyle=":")
+    ax.grid(True, linestyle=':')
 
 
 def elub(

--- a/lir/algorithms/invariance_bounds.py
+++ b/lir/algorithms/invariance_bounds.py
@@ -7,8 +7,8 @@ See:
     In: Submitted for publication in 2025.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from lir.bounding import LLRBounder
 from lir.util import logodds_to_odds, odds_to_logodds
@@ -48,20 +48,20 @@ def plot_invariance_delta_functions(
     ax.plot(
         llr_threshold,
         delta_low,
-        "--",
-        label=r"$\Delta_{lower}$ is 0 at " + str(lower_llr),
+        '--',
+        label=r'$\Delta_{lower}$ is 0 at ' + str(lower_llr),
     )
     ax.plot(
         llr_threshold,
         delta_high,
-        "-",
-        label=r"$\Delta_{upper}$ is 0 at " + str(upper_llr),
+        '-',
+        label=r'$\Delta_{upper}$ is 0 at ' + str(upper_llr),
     )
-    ax.axhline(color="k", linestyle="dotted")
+    ax.axhline(color='k', linestyle='dotted')
     # Some more formatting
-    ax.legend(loc="upper left")
-    ax.set_xlabel("log10(LR)")
-    ax.set_ylabel(r"$\Delta$-value")
+    ax.legend(loc='upper left')
+    ax.set_xlabel('log10(LR)')
+    ax.set_ylabel(r'$\Delta$-value')
 
 
 def calculate_invariance_bounds(

--- a/lir/algorithms/isotonic_regression.py
+++ b/lir/algorithms/isotonic_regression.py
@@ -1,6 +1,6 @@
 import numpy as np
-from sklearn.base import BaseEstimator, TransformerMixin
 import sklearn.isotonic
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array, check_consistent_length
 
 from lir.util import probability_to_logodds
@@ -13,7 +13,7 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
     prevents the error being thrown when Inf or -Inf values are provided.
     """
 
-    def fit(self, X, y, sample_weight=None) -> "IsotonicRegression":
+    def fit(self, X, y, sample_weight=None) -> 'IsotonicRegression':
         """Fit the model using X, y as training data.
 
         Parameters
@@ -38,7 +38,7 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
         X is stored for future use, as :meth:`transform` needs X to interpolate
         new input data.
         """
-        check_params = dict(accept_sparse=False, ensure_2d=False, ensure_all_finite=False)
+        check_params = dict(accept_sparse=False, ensure_2d=False, ensure_all_finite=False)  # noqa: C408
         X = check_array(X, dtype=[np.float64, np.float32], **check_params)
         y = check_array(y, dtype=X.dtype, **check_params)
         check_consistent_length(X, y, sample_weight)
@@ -71,23 +71,20 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
             The transformed data
         """
 
-        if hasattr(self, "_necessary_X_"):
-            dtype = self._necessary_X_.dtype
-        else:
-            dtype = np.float64
+        dtype = self._necessary_X_.dtype if hasattr(self, '_necessary_X_') else np.float64
 
         T = check_array(T, dtype=dtype, ensure_2d=False, ensure_all_finite=False)
 
         if len(T.shape) != 1:
-            raise ValueError("Isotonic regression input should be a 1d array")
+            raise ValueError('Isotonic regression input should be a 1d array')
 
         # Handle the out_of_bounds argument by clipping if needed
-        if self.out_of_bounds not in ["raise", "nan", "clip"]:
+        if self.out_of_bounds not in ['raise', 'nan', 'clip']:
             raise ValueError(
-                "The argument ``out_of_bounds`` must be in 'nan', 'clip', 'raise'; got {0}".format(self.out_of_bounds)
+                f"The argument ``out_of_bounds`` must be in 'nan', 'clip', 'raise'; got {self.out_of_bounds}"
             )
 
-        if self.out_of_bounds == "clip":
+        if self.out_of_bounds == 'clip':
             T = np.clip(T, self.X_min_, self.X_max_)
 
         res = self.f_(T)
@@ -114,10 +111,10 @@ class IsotonicCalibrator(BaseEstimator, TransformerMixin):
         :param add_misleading:
         """
         self.add_misleading = add_misleading
-        self._ir = IsotonicRegression(out_of_bounds="clip")
+        self._ir = IsotonicRegression(out_of_bounds='clip')
 
-    def fit(self, X: np.ndarray, y: np.ndarray) -> "IsotonicCalibrator":
-        assert np.all(np.unique(y) == np.arange(2)), "y labels must be 0 and 1"
+    def fit(self, X: np.ndarray, y: np.ndarray) -> 'IsotonicCalibrator':
+        assert np.all(np.unique(y) == np.arange(2)), 'y labels must be 0 and 1'
 
         # prevent extreme LRs
         if self.add_misleading > 0:

--- a/lir/algorithms/kde.py
+++ b/lir/algorithms/kde.py
@@ -1,14 +1,15 @@
-from collections.abc import Callable
 import logging
 import math
 import warnings
-from typing import Sized, Self
+from collections.abc import Callable, Sized
+from typing import Self
 
 import numpy as np
-from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.neighbors import KernelDensity
 
-from lir.util import ln_to_log10, Xy_to_Xn, check_misleading_finite
+from lir.util import Xy_to_Xn, check_misleading_finite, ln_to_log10
+
 
 LOG = logging.getLogger(__name__)
 
@@ -69,10 +70,11 @@ class KDECalibrator(BaseEstimator, TransformerMixin):
             if std == 0:
                 # can happen eg if std(values) = 0
                 warnings.warn(
-                    "silverman bandwidth cannot be calculated if standard deviation is 0",
+                    'silverman bandwidth cannot be calculated if standard deviation is 0',
                     RuntimeWarning,
+                    stacklevel=2,
                 )
-                LOG.info("found a silverman bandwidth of 0 (using dummy value)")
+                LOG.info('found a silverman bandwidth of 0 (using dummy value)')
                 std = 1
 
             v = math.pow(std, 5) / len(values) * 4.0 / 3
@@ -93,14 +95,14 @@ class KDECalibrator(BaseEstimator, TransformerMixin):
         X1 = X1.reshape(-1, 1)
 
         bandwidth0, bandwidth1 = self.bandwidth(X, y)
-        self._kde0 = KernelDensity(kernel="gaussian", bandwidth=bandwidth0).fit(X0)
-        self._kde1 = KernelDensity(kernel="gaussian", bandwidth=bandwidth1).fit(X1)
+        self._kde0 = KernelDensity(kernel='gaussian', bandwidth=bandwidth0).fit(X0)
+        self._kde1 = KernelDensity(kernel='gaussian', bandwidth=bandwidth1).fit(X1)
         return self
 
     def transform(self, X: np.ndarray) -> np.ndarray:
         """Provide LLR's as output."""
         if self._kde0 is None or self._kde1 is None or self.numerator is None or self.denominator is None:
-            raise ValueError("KDECalibrator.transform() called before fit")
+            raise ValueError('KDECalibrator.transform() called before fit')
 
         self.p0 = np.empty(np.shape(X))
         self.p1 = np.empty(np.shape(X))
@@ -151,17 +153,17 @@ class KDECalibrator(BaseEstimator, TransformerMixin):
         :return: bandwidth used for kde0, bandwidth used for kde1
         """
         if bandwidth is None:
-            raise ValueError("missing bandwidth argument for KDE")
+            raise ValueError('missing bandwidth argument for KDE')
         elif callable(bandwidth):
             return bandwidth
-        elif bandwidth == "silverman":
+        elif bandwidth == 'silverman':
             return KDECalibrator.bandwidth_silverman
         elif isinstance(bandwidth, str):
-            raise ValueError(f"invalid input for bandwidth: {bandwidth}")
+            raise ValueError(f'invalid input for bandwidth: {bandwidth}')
         elif isinstance(bandwidth, Sized):
-            assert (
-                len(bandwidth) == 2
-            ), f"bandwidth should have two elements; found {len(bandwidth)}; bandwidth = {bandwidth}"
+            assert len(bandwidth) == 2, (
+                f'bandwidth should have two elements; found {len(bandwidth)}; bandwidth = {bandwidth}'
+            )
             return lambda X, y: bandwidth
         else:
             return lambda X, y: (0 + bandwidth, bandwidth)

--- a/lir/algorithms/percentile_rank.py
+++ b/lir/algorithms/percentile_rank.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+
 import numpy as np
 import sklearn
 from scipy.interpolate import interp1d
@@ -38,21 +39,21 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
     def __init__(self) -> None:
         self.rank_functions: list[Callable] | None = None
 
-    def fit(self, X: np.ndarray, y: np.ndarray | None = None) -> "PercentileRankTransformer":
+    def fit(self, X: np.ndarray, y: np.ndarray | None = None) -> 'PercentileRankTransformer':
         X = X.reshape(X.shape[0], -1)
-        ranks_X = rankdata(X, method="max", axis=0) / X.shape[0]
+        ranks_X = rankdata(X, method='max', axis=0) / X.shape[0]
         self.rank_functions = [
             interp1d(X[:, i], ranks_X[:, i], bounds_error=False, fill_value=(0, 1)) for i in range(X.shape[1])
         ]
         return self
 
     def transform(self, X: np.ndarray) -> np.ndarray:
-        assert self.rank_functions, "transform() called before fit()"
+        assert self.rank_functions, 'transform() called before fit()'
         original_shape = X.shape
         X = X.reshape(X.shape[0], -1)
         assert X.shape[1] == len(self.rank_functions), (
-            f"number of features {X.shape[1]} does not match "
-            "the number of features {len(self.rank_functions)} used for fit()"
+            f'number of features {X.shape[1]} does not match '
+            'the number of features {len(self.rank_functions)} used for fit()'
         )
         ranks = [self.rank_functions[i](X[:, i]) for i in range(X.shape[1])]
         return np.stack(ranks, axis=1).reshape(*original_shape)

--- a/lir/bounding.py
+++ b/lir/bounding.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 
 import numpy as np
 from sklearn.base import TransformerMixin
@@ -30,17 +30,17 @@ class LLRBounder(TransformerMixin, ABC):
     @staticmethod
     def _validate(llrs: np.ndarray, labels: np.ndarray) -> None:
         if len(llrs.shape) != 1:
-            raise ValueError(f"llrs argument should be 1-dimensional; dimensions found: {len(llrs.shape)}")
+            raise ValueError(f'llrs argument should be 1-dimensional; dimensions found: {len(llrs.shape)}')
         if len(labels.shape) != 1:
-            raise ValueError(f"labels argument should be 1-dimensional; dimensions found: {len(labels.shape)}")
+            raise ValueError(f'labels argument should be 1-dimensional; dimensions found: {len(labels.shape)}')
         if llrs.shape[0] != labels.shape[0]:
             raise ValueError(
-                f"number of labels does not match the number of llrs ({labels.shape[0]} != {llrs.shape[0]})"
+                f'number of labels does not match the number of llrs ({labels.shape[0]} != {llrs.shape[0]})'
             )
         if list(np.unique(labels)) != [0, 1]:
-            raise ValueError(f"labels expected: 0, 1; found: {np.unique(labels)}")
+            raise ValueError(f'labels expected: 0, 1; found: {np.unique(labels)}')
 
-    def fit(self, llrs: np.ndarray, labels: np.ndarray) -> "LLRBounder":
+    def fit(self, llrs: np.ndarray, labels: np.ndarray) -> 'LLRBounder':
         """
         Configures this bounder by calculating bounds.
 
@@ -59,8 +59,8 @@ class LLRBounder(TransformerMixin, ABC):
             and self.lower_llr_bound > self.upper_llr_bound
         ):
             raise ValueError(
-                "the lower bound must be lower than the upper bound; "
-                f"lower_llr_bound={self.lower_llr_bound}; upper_llr_bound={self.upper_llr_bound}"
+                'the lower bound must be lower than the upper bound; '
+                f'lower_llr_bound={self.lower_llr_bound}; upper_llr_bound={self.upper_llr_bound}'
             )
 
         return self

--- a/lir/config/__init__.py
+++ b/lir/config/__init__.py
@@ -1,5 +1,5 @@
 # This import is used to be able to write a short-hand version in `registry.yaml`, i.e.
 # `lir.config.numpy_csv_writer`. Ignored by linting (F401; unused import).
 from .transform import (  # noqa: F401
-    NumpyCsvWriterWrappingConfigParser as numpy_csv_writer,
+    NumpyCsvWriterWrappingConfigParser as numpy_csv_writer,  # noqa: N813
 )

--- a/lir/config/base.py
+++ b/lir/config/base.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-
-from typing import Any, Mapping
+from typing import Any
 
 from lir import registry
 from lir.transform.pairing import PairingMethod
@@ -12,8 +11,8 @@ class YamlParseError(ValueError):
     """Error raised when parsing YAML configuration fails, mentioning specific YAML path."""
 
     def __init__(self, config_context_path: list[str], message: str):
-        prefix = f"{'.'.join(config_context_path)}: " if config_context_path else ""
-        super().__init__(f"{prefix}{message}")
+        prefix = f'{".".join(config_context_path)}: ' if config_context_path else ''
+        super().__init__(f'{prefix}{message}')
 
 
 class ContextAwareDict(dict):
@@ -21,7 +20,7 @@ class ContextAwareDict(dict):
         super().__init__(*args, **kwargs)
         self.context = context
 
-    def clone(self, context: list[str] | None = None) -> "ContextAwareDict":
+    def clone(self, context: list[str] | None = None) -> 'ContextAwareDict':
         return _expand(context if context is not None else self.context, self)
 
 
@@ -30,7 +29,7 @@ class ContextAwareList(list):
         super().__init__(*args, **kwargs)
         self.context = context
 
-    def clone(self, context: list[str] | None = None) -> "ContextAwareList":
+    def clone(self, context: list[str] | None = None) -> 'ContextAwareList':
         return _expand(context if context is not None else self.context, self)
 
 
@@ -86,7 +85,7 @@ class GenericFunctionConfigParser(ConfigParser):
         if callable(self.component_class):
             return self.component_class
 
-        raise YamlParseError(config.context, f"unrecognized module type: `{self.component_class}`")
+        raise YamlParseError(config.context, f'unrecognized module type: `{self.component_class}`')
 
 
 class GenericConfigParser(ConfigParser):
@@ -108,7 +107,7 @@ class GenericConfigParser(ConfigParser):
         except Exception as e:
             raise YamlParseError(
                 config.context,
-                f"unable to initialize {self.component_class}; the error was: {e}",
+                f'unable to initialize {self.component_class}; the error was: {e}',
             )
 
 
@@ -166,10 +165,10 @@ def parse_pairing_config(
         class_name = module_config
         args = ContextAwareDict(context)
     else:
-        class_name = pop_field(module_config, "method")
+        class_name = pop_field(module_config, 'method')
         args = module_config
 
-    return registry.get(class_name, search_path=["pairing"], default_config_parser=GenericConfigParser).parse(
+    return registry.get(class_name, search_path=['pairing'], default_config_parser=GenericConfigParser).parse(
         args, output_dir
     )
 
@@ -196,24 +195,24 @@ def pop_field(
     # get required status and default value from function arguments
     required = required if required is not None else (default is None)
     if default is not None and required:
-        raise ValueError(f"illegal argument values: required={required}; default={default}")
+        raise ValueError(f'illegal argument values: required={required}; default={default}')
 
     # if there is a configuration, it should be a `dict`, and we will try to get the field value from it
     if config:
         if not isinstance(config, ContextAwareDict):
-            raise YamlParseError(config.context, f"expected dict; found: {type(config)}")
-        elif field in config.keys():
+            raise YamlParseError(config.context, f'expected dict; found: {type(config)}')
+        elif field in config:
             value = config.pop(field)
             if validate:
                 try:
                     value = validate(value)
                 except Exception as e:
-                    raise YamlParseError(config.context, f"illegal value for field `{field}`: {e}")
+                    raise YamlParseError(config.context, f'illegal value for field `{field}`: {e}')
             return value
 
     # if no field value was returned, return the default value or raise an error
     if required:
-        raise YamlParseError(config.context, f"missing field: `{field}`")
+        raise YamlParseError(config.context, f'missing field: `{field}`')
     else:
         return default
 
@@ -229,4 +228,4 @@ def check_is_empty(
     the user does not assume arguments are parsed that are in fact not recognized."""
     for key in config:
         if not accept_keys or key not in accept_keys:
-            raise YamlParseError(config.context, f"unrecognized argument: {key}")
+            raise YamlParseError(config.context, f'unrecognized argument: {key}')

--- a/lir/config/data_providers.py
+++ b/lir/config/data_providers.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 from lir import registry
 from lir.config.base import (
-    YamlParseError,
     GenericConfigParser,
+    YamlParseError,
     pop_field,
 )
 from lir.config.substitution import ContextAwareDict
@@ -19,18 +19,18 @@ def parse_data_provider(cfg: ContextAwareDict, output_path: Path) -> DataSet:
 
     Data sources are provided under the `data_sources` key.
     """
-    provider = pop_field(cfg, "provider")
+    provider = pop_field(cfg, 'provider')
 
     try:
         parser = registry.get(
             provider,
-            search_path=["data_providers"],
+            search_path=['data_providers'],
             default_config_parser=GenericConfigParser,
         )
     except Exception as e:
         raise YamlParseError(
             cfg.context,
-            f"no parser available for data provider `{provider}`; the error was: {e}",
+            f'no parser available for data provider `{provider}`; the error was: {e}',
         )
 
     return parser.parse(cfg, output_path)

--- a/lir/config/data_strategies.py
+++ b/lir/config/data_strategies.py
@@ -3,18 +3,18 @@ from pathlib import Path
 
 from lir import registry
 from lir.config.base import (
+    GenericConfigParser,
     YamlParseError,
+    check_is_empty,
     config_parser,
     pop_field,
-    check_is_empty,
-    GenericConfigParser,
 )
 from lir.config.data_providers import parse_data_provider
 from lir.config.substitution import ContextAwareDict
 from lir.data.data_strategies import (
     BinaryCrossValidation,
-    MulticlassCrossValidation,
     BinaryTrainTestSplit,
+    MulticlassCrossValidation,
     MulticlassTrainTestSplit,
 )
 from lir.data.models import DataStrategy
@@ -25,9 +25,9 @@ def _parse_train_test_split(
     output_path: Path,
     constructor: Callable,
 ) -> DataStrategy:
-    data_source = parse_data_provider(pop_field(config, "source"), output_path)
-    test_size = pop_field(config, "test_size")
-    seed = config.pop("seed", None)
+    data_source = parse_data_provider(pop_field(config, 'source'), output_path)
+    test_size = pop_field(config, 'test_size')
+    seed = config.pop('seed', None)
     check_is_empty(config)
     return constructor(data_source, test_size, seed)
 
@@ -54,8 +54,8 @@ def _parse_cross_validation(
     constructor: Callable,
     extra_args: Sequence[str],
 ) -> DataStrategy:
-    folds = int(pop_field(config, "folds"))
-    data_source = parse_data_provider(pop_field(config, "source"), output_path)
+    folds = int(pop_field(config, 'folds'))
+    data_source = parse_data_provider(pop_field(config, 'source'), output_path)
     check_is_empty(config, extra_args)
     return constructor(data_source, folds, **config)
 
@@ -86,7 +86,7 @@ def binary_cross_validation(config: ContextAwareDict, output_path: Path) -> Data
         data: ${binary_cross_validation_splits}
         ...
     """
-    return _parse_cross_validation(config, output_path, BinaryCrossValidation, ["seed"])
+    return _parse_cross_validation(config, output_path, BinaryCrossValidation, ['seed'])
 
 
 @config_parser
@@ -129,18 +129,18 @@ def parse_data_strategy(cfg: ContextAwareDict, output_path: Path) -> DataStrateg
 
     Data setup configuration is provided under the `data_setup` key.
     """
-    strategy = pop_field(cfg, "strategy")
+    strategy = pop_field(cfg, 'strategy')
 
     try:
         parser = registry.get(
             strategy,
-            search_path=["data_strategies"],
+            search_path=['data_strategies'],
             default_config_parser=GenericConfigParser,
         )
     except Exception as e:
         raise YamlParseError(
             cfg.context,
-            f"no parser available for data type `{strategy}`; the error was: {e}",
+            f'no parser available for data type `{strategy}`; the error was: {e}',
         )
 
     return parser.parse(cfg, output_path)

--- a/lir/config/lrsystem_architectures.py
+++ b/lir/config/lrsystem_architectures.py
@@ -10,9 +10,9 @@ from lir.config.base import (
     pop_field,
 )
 from lir.config.substitution import (
-    substitute_hyperparameters,
-    HyperparameterOption,
     ContextAwareDict,
+    HyperparameterOption,
+    substitute_hyperparameters,
 )
 from lir.config.transform import parse_module
 from lir.lrsystems.lrsystems import LRSystem
@@ -21,6 +21,7 @@ from lir.lrsystems.specific_source import SpecificSourceSystem
 from lir.lrsystems.two_level import TwoLevelSystem
 from lir.registry import ComponentNotFoundError
 from lir.transform.pipeline import Pipeline
+
 
 LOG = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def specific_source(config: ContextAwareDict, output_dir: Path) -> LRSystem:
     The `specific_source` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.specific_source`.
     """
-    pipeline = parse_pipeline(pop_field(config, "modules"), output_dir)
+    pipeline = parse_pipeline(pop_field(config, 'modules'), output_dir)
     return SpecificSourceSystem(output_dir.name, pipeline)
 
 
@@ -64,20 +65,20 @@ def score_based(config: ContextAwareDict, output_dir: Path) -> LRSystem:
     The `specific_source` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.score_based`.
     """
-    preprocessing = parse_pipeline(pop_field(config, "preprocessing"), output_dir)
-    pairing_function = parse_pairing_config(pop_field(config, "pairing"), output_dir, config.context)
-    evaluation = parse_pipeline(pop_field(config, "comparing"), output_dir)
+    preprocessing = parse_pipeline(pop_field(config, 'preprocessing'), output_dir)
+    pairing_function = parse_pairing_config(pop_field(config, 'pairing'), output_dir, config.context)
+    evaluation = parse_pipeline(pop_field(config, 'comparing'), output_dir)
 
     return ScoreBasedSystem(output_dir.name, preprocessing, pairing_function, evaluation)
 
 
 @config_parser
 def two_level(config: ContextAwareDict, output_dir: Path) -> LRSystem:
-    preprocessing = parse_pipeline(pop_field(config, "preprocessing"), output_dir)
-    pairing_function = parse_pairing_config(pop_field(config, "pairing"), output_dir, config.context)
-    postprocessing = parse_pipeline(pop_field(config, "postprocessing"), output_dir)
-    n_trace_instances = pop_field(config, "n_trace_instances", validate=int)
-    n_ref_instances = pop_field(config, "n_ref_instances", validate=int)
+    preprocessing = parse_pipeline(pop_field(config, 'preprocessing'), output_dir)
+    pairing_function = parse_pairing_config(pop_field(config, 'pairing'), output_dir, config.context)
+    postprocessing = parse_pipeline(pop_field(config, 'postprocessing'), output_dir)
+    n_trace_instances = pop_field(config, 'n_trace_instances', validate=int)
+    n_ref_instances = pop_field(config, 'n_ref_instances', validate=int)
 
     return TwoLevelSystem(
         output_dir.name,
@@ -94,12 +95,12 @@ def parse_lrsystem(config: ContextAwareDict, output_dir: Path) -> LRSystem:
 
     LR systems are provided under the `architectures` key.
     """
-    architecture = pop_field(config, "architecture")
+    architecture = pop_field(config, 'architecture')
 
     try:
-        parser = registry.get(architecture, search_path=["lrsystem_architectures"])
+        parser = registry.get(architecture, search_path=['lrsystem_architectures'])
     except ComponentNotFoundError as e:
-        raise YamlParseError(config.context, f"{e}")
+        raise YamlParseError(config.context, f'{e}')
 
     return parser.parse(config, output_dir)
 
@@ -108,7 +109,7 @@ def parse_augmented_lrsystem(
     baseline_lrsystem_config: ContextAwareDict,
     hyperparameters: dict[str, HyperparameterOption],
     output_dir: Path,
-    dirname_prefix: str = "",
+    dirname_prefix: str = '',
 ) -> LRSystem:
     """
     Parses an augmented LR system.
@@ -126,12 +127,12 @@ def parse_augmented_lrsystem(
     """
     substitutions = dict(itertools.chain(*[opt.substitutions.items() for opt in hyperparameters.values()]))
 
-    name = "__".join([f"{key}={value}" for key, value in hyperparameters.items()])
-    context = baseline_lrsystem_config.context + [f"substitution[{name}]"]
+    name = '__'.join([f'{key}={value}' for key, value in hyperparameters.items()])
+    context = baseline_lrsystem_config.context + [f'substitution[{name}]']
     augmented_config = substitute_hyperparameters(baseline_lrsystem_config, substitutions, context)
     lrsystem = parse_lrsystem(
         augmented_config,
-        output_dir / f"{dirname_prefix}{name}",
+        output_dir / f'{dirname_prefix}{name}',
     )
     lrsystem.parameters = hyperparameters
     return lrsystem

--- a/lir/config/substitution.py
+++ b/lir/config/substitution.py
@@ -23,23 +23,24 @@ benchmarks:
 ```
 """
 
-from collections.abc import Mapping
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, NamedTuple
 
 from lir import registry
 from lir.config.base import (
-    YamlParseError,
-    check_is_empty,
-    pop_field,
-    config_parser,
     ContextAwareDict,
-    _expand,
     ContextAwareList,
+    YamlParseError,
+    _expand,
+    check_is_empty,
+    config_parser,
+    pop_field,
 )
+
 
 LOG = logging.getLogger(__name__)
 
@@ -101,21 +102,17 @@ def _parse_categorical_option(spec: Any, path: str, option_index: int | None) ->
     name = None
     if isinstance(spec, Mapping):
         # use the explicityly declared name, if any
-        name = pop_field(spec, "option_name", required=False)
+        name = pop_field(spec, 'option_name', required=False)
 
     # use the explicitly declared value, or default to the full subtree
-    value = None
-    if isinstance(spec, Mapping) and "value" in spec:
-        value = pop_field(spec, "value")
-    else:
-        value = spec
+    value = pop_field(spec, 'value') if isinstance(spec, Mapping) and 'value' in spec else spec
 
     if name:
         pass
     elif isinstance(value, str):
         name = value
-    elif isinstance(value, Mapping) or isinstance(value, list):
-        name = f"option{option_index}"
+    elif isinstance(value, (Mapping, list)):
+        name = f'option{option_index}'
     else:
         name = str(value)
 
@@ -123,13 +120,13 @@ def _parse_categorical_option(spec: Any, path: str, option_index: int | None) ->
 
 
 @config_parser
-def parse_categorical(spec: ContextAwareDict, output_path: Path) -> "CategoricalHyperparameter":
+def parse_categorical(spec: ContextAwareDict, output_path: Path) -> 'CategoricalHyperparameter':
     """Parse the `parameters` section of the configuration into a `CategoricalVariable` object."""
-    path = pop_field(spec, "path")
-    name = pop_field(spec, "name", default=path or "lrsystem")
+    path = pop_field(spec, 'path')
+    name = pop_field(spec, 'name', default=path or 'lrsystem')
 
     # get the option definitions
-    options = pop_field(spec, "options")
+    options = pop_field(spec, 'options')
     options = [_parse_categorical_option(spec, path, i) for i, spec in enumerate(options)]
 
     check_is_empty(spec)
@@ -137,15 +134,15 @@ def parse_categorical(spec: ContextAwareDict, output_path: Path) -> "Categorical
 
 
 def _parse_substitution(spec: ContextAwareDict) -> tuple[str, Any]:
-    path = pop_field(spec, "path")
-    value = pop_field(spec, "value")
+    path = pop_field(spec, 'path')
+    value = pop_field(spec, 'value')
     check_is_empty(spec)
     return path, value
 
 
 def _parse_clustered_option(spec: ContextAwareDict) -> HyperparameterOption:
-    option_name = pop_field(spec, "option_name")
-    substitutions = pop_field(spec, "substitutions")
+    option_name = pop_field(spec, 'option_name')
+    substitutions = pop_field(spec, 'substitutions')
     substitutions = [_parse_substitution(subst) for i, subst in enumerate(substitutions)]
     substitutions = dict(substitutions)
     check_is_empty(spec)
@@ -167,8 +164,8 @@ def parse_clustered(spec: ContextAwareDict, output_path: Path) -> CategoricalHyp
     - name: a descriptive name for this option
     - substitutions: a list of substitutions, with a `path` and `value` field each
     """
-    parameter_name = pop_field(spec, "name")
-    options = pop_field(spec, "options")
+    parameter_name = pop_field(spec, 'name')
+    options = pop_field(spec, 'options')
     options = [_parse_clustered_option(option) for i, option in enumerate(options)]
     check_is_empty(spec)
     return CategoricalHyperparameter(parameter_name, options)
@@ -185,8 +182,8 @@ def parse_constant(spec: ContextAwareDict, output_path: Path) -> CategoricalHype
     - path: the path of this hyperparameter in the LR system configuration
     - value: the substitution value
     """
-    path = pop_field(spec, "path")
-    value = pop_field(spec, "value")
+    path = pop_field(spec, 'path')
+    value = pop_field(spec, 'value')
     value = _parse_categorical_option(value, path, 0)
     check_is_empty(spec)
     return CategoricalHyperparameter(path, [value])
@@ -216,7 +213,7 @@ class FloatHyperparameter(Hyperparameter):
     def options(self) -> list[HyperparameterOption]:
         if self.step is None:
             raise ValueError(
-                f"unable to generate options for floating point hyperparameter {self.path}: no step size defined"
+                f'unable to generate options for floating point hyperparameter {self.path}: no step size defined'
             )
 
         n_steps = int((self.high - self.low) // self.step + 1)
@@ -225,18 +222,18 @@ class FloatHyperparameter(Hyperparameter):
 
 
 @config_parser
-def parse_float(spec: ContextAwareDict, output_path: Path) -> "FloatHyperparameter":
+def parse_float(spec: ContextAwareDict, output_path: Path) -> 'FloatHyperparameter':
     """Parse the `parameters` section of the configuration into a `CategoricalVariable` object."""
-    path = pop_field(spec, "path")
-    low = pop_field(spec, "low")
-    high = pop_field(spec, "high")
-    log = pop_field(spec, "log", default=False)
-    step = pop_field(spec, "step", required=False)
+    path = pop_field(spec, 'path')
+    low = pop_field(spec, 'low')
+    high = pop_field(spec, 'high')
+    log = pop_field(spec, 'log', default=False)
+    step = pop_field(spec, 'step', required=False)
 
     if log and step is not None:
         raise YamlParseError(
             spec.context,
-            "configuration field `log` and `step` cannot be cannot be combined",
+            'configuration field `log` and `step` cannot be cannot be combined',
         )
 
     check_is_empty(spec)
@@ -251,22 +248,22 @@ def parse_hyperparameter(
     Parse the parameters section of the configuration into a dedicated value wrapper object.
     """
 
-    if "type" in spec:
-        parameter_type = pop_field(spec, "type")  # read from specified configuration
+    if 'type' in spec:
+        parameter_type = pop_field(spec, 'type')  # read from specified configuration
 
-        parser = registry.get(parameter_type, search_path=["hyperparameter_types"])
-    elif "value" in spec:
+        parser = registry.get(parameter_type, search_path=['hyperparameter_types'])
+    elif 'value' in spec:
         parser = parse_constant()
-    elif "options" in spec and "path" in spec:
+    elif 'options' in spec and 'path' in spec:
         parser = parse_categorical()
-    elif "options" in spec and "name" in spec:
+    elif 'options' in spec and 'name' in spec:
         parser = parse_clustered()
-    elif "high" in spec:
+    elif 'high' in spec:
         parser = parse_float()
     else:
         raise YamlParseError(
             spec.context,
-            f"unrecognized hyperparameter type with fields: {', '.join(f'{key}' for key in spec.keys())}",
+            f'unrecognized hyperparameter type with fields: {", ".join(f"{key}" for key in spec)}',
         )
 
     return parser.parse(spec, output_dir)
@@ -298,11 +295,11 @@ def _path_exists(struct: dict | list, path: list[str]) -> bool:
     index = int(path[0]) if isinstance(struct, list) else path[0]
 
     if index not in struct:
-        if isinstance(struct, dict):
-            options = ", ".join(struct.keys())
+        if isinstance(struct, dict):  # noqa: SIM108
+            options = ', '.join(struct.keys())
         else:
-            options = f"0..{len(struct) - 1}"
-        raise ValueError(f"no such key: {index}; found: {options}")
+            options = f'0..{len(struct) - 1}'
+        raise ValueError(f'no such key: {index}; found: {options}')
 
     if len(path) == 1:
         return index in struct
@@ -322,14 +319,14 @@ def substitute_hyperparameters(
     :return: the augmented LR system configuration
     """
 
-    if "" in hyperparameters:
+    if '' in hyperparameters:
         # if the root is assigned, don't bother substituting and return the assigned value immediately
-        augmented_config = _expand(context, hyperparameters[""])
+        augmented_config = _expand(context, hyperparameters[''])
     else:
-        LOG.debug(f"base system: {json.dumps(base_config)}")
+        LOG.debug(f'base system: {json.dumps(base_config)}')
         augmented_config = base_config.clone(context)
         for key, value in hyperparameters.items():
-            _assign(augmented_config, key.split("."), value)
+            _assign(augmented_config, key.split('.'), value)
 
-    LOG.debug(f"augmented system: {json.dumps(augmented_config)}")
+    LOG.debug(f'augmented system: {json.dumps(augmented_config)}')
     return augmented_config

--- a/lir/config/util.py
+++ b/lir/config/util.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from typing import Any
 
-
-from lir.config.base import ConfigParser, pop_field, ContextAwareDict
+from lir.config.base import ConfigParser, ContextAwareDict, pop_field
 from lir.config.transform import parse_module
 from lir.transform import Tee
 
@@ -14,7 +13,7 @@ class TeeParser(ConfigParser):
         output_dir: Path,
     ) -> Any:
         transformers = []
-        modules = pop_field(config, "modules")
+        modules = pop_field(config, 'modules')
         for module_config in modules:
             transformers.append(parse_module(module_config, output_dir, module_config.context))
 

--- a/lir/config/visualization.py
+++ b/lir/config/visualization.py
@@ -1,8 +1,8 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from lir import registry
-from lir.config.base import GenericFunctionConfigParser, YamlParseError, ContextAwareDict
+from lir.config.base import ContextAwareDict, GenericFunctionConfigParser, YamlParseError
 from lir.registry import ComponentNotFoundError
 
 
@@ -20,7 +20,7 @@ def parse_visualizations(config: ContextAwareDict, output_path: Path) -> list[Ca
             parser = registry.get(
                 visualization_type,
                 default_config_parser=GenericFunctionConfigParser,
-                search_path=["visualization"],
+                search_path=['visualization'],
             )
             func = parser.parse(config, output_path)
             visualization_functions.append(func)

--- a/lir/data/data_strategies.py
+++ b/lir/data/data_strategies.py
@@ -1,8 +1,8 @@
-from typing import Iterator
+from collections.abc import Iterator
 
 import numpy as np
 import sklearn
-from sklearn.model_selection import KFold, GroupKFold, GroupShuffleSplit
+from sklearn.model_selection import GroupKFold, GroupShuffleSplit, KFold
 
 from lir.data.models import DataSet, DataStrategy
 
@@ -17,7 +17,7 @@ class BinaryTrainTestSplit(DataStrategy):
         self.source = source
         self.test_size = test_size
         self.seed = seed
-        self.shuffle = True if self.seed is not None else False
+        self.shuffle = True if self.seed is not None else False  # noqa: SIM210
 
     def __iter__(self) -> Iterator:
         """Allow iteration by looping over the resulting train/test split(s)."""
@@ -41,13 +41,13 @@ class BinaryCrossValidation(DataStrategy):
         self.source = source
         self.folds = folds
         self.seed = seed
-        self.shuffle = True if self.seed is not None else False
+        self.shuffle = True if self.seed is not None else False  # noqa: SIM210
 
     def __iter__(self) -> Iterator:
         """Allow iteration by looping over the resulting train/test split(s)."""
         kf = KFold(n_splits=self.folds, shuffle=self.shuffle, random_state=self.seed)
         instances = self.source.get_instances()
-        for i, (train_index, test_index) in enumerate(kf.split(instances.features, y=instances.labels)):
+        for _i, (train_index, test_index) in enumerate(kf.split(instances.features, y=instances.labels)):
             yield instances[train_index], instances[test_index]
 
 
@@ -86,5 +86,5 @@ class MulticlassCrossValidation(DataStrategy):
         kf = GroupKFold(n_splits=self.folds)
 
         instances = self.source.get_instances()
-        for i, (train_index, test_index) in enumerate(kf.split(instances.features, groups=instances.labels)):
+        for _i, (train_index, test_index) in enumerate(kf.split(instances.features, groups=instances.labels)):
             yield instances[train_index], instances[test_index]

--- a/lir/data/datasets/glass.py
+++ b/lir/data/datasets/glass.py
@@ -1,7 +1,7 @@
 import csv
+from collections.abc import Iterator
 from os import PathLike
 from pathlib import Path
-from typing import Iterator
 
 import numpy as np
 
@@ -28,7 +28,7 @@ class GlassData(DataSet, DataStrategy):
 
     def __init__(self, cache_dir: PathLike):
         self.resources = RemoteResource(
-            "https://raw.githubusercontent.com/NetherlandsForensicInstitute/elemental_composition_glass/main",
+            'https://raw.githubusercontent.com/NetherlandsForensicInstitute/elemental_composition_glass/main',
             Path(cache_dir),
         )
 
@@ -39,14 +39,14 @@ class GlassData(DataSet, DataStrategy):
         labels = []
         origins = []
         values = []
-        with self.resources.open(file, "r") as f:
+        with self.resources.open(file, 'r') as f:
             reader = csv.DictReader(f)
             for i, row in enumerate(reader):
                 # the first measurement is at row 2, since row 1 is the header
                 row_number = i + 2
 
-                labels.append(int(row["Item"]))
-                origins.append(f"{file}:{row_number}")
+                labels.append(int(row['Item']))
+                origins.append(f'{file}:{row_number}')
                 values.append(np.array(list(map(float, row.values()))[3:]))
 
         return np.array(values), np.array(labels), np.array(origins).reshape(-1, 1)
@@ -60,11 +60,15 @@ class GlassData(DataSet, DataStrategy):
 
         The data are returned as a tuple of features, labels, and metadata, similar to `get_instances()`.
         """
-        training_data = self._load_data("training.csv")
+        training_data = self._load_data('training.csv')
         training_data = FeatureData(
-            features=training_data[0], labels=training_data[1], meta=training_data[2]  # type: ignore
+            features=training_data[0],
+            labels=training_data[1],
+            meta=training_data[2],  # type: ignore
         )
-        test_features, test_labels, test_meta = zip(self._load_data("duplo.csv"), self._load_data("triplo.csv"))
+        test_features, test_labels, test_meta = zip(
+            self._load_data('duplo.csv'), self._load_data('triplo.csv'), strict=True
+        )
         test_data = FeatureData(
             features=np.concatenate(test_features),
             labels=np.concatenate(test_labels),
@@ -85,5 +89,5 @@ class GlassData(DataSet, DataStrategy):
 
         The meta values of an instance are a concatenation of the filename and a row number, e.g. "training.csv:22".
         """
-        features, labels, meta = self._load_data("training.csv")
+        features, labels, meta = self._load_data('training.csv')
         return FeatureData(features=features, labels=labels, meta=meta)  # type: ignore

--- a/lir/data/datasets/synthesized_normal_binary.py
+++ b/lir/data/datasets/synthesized_normal_binary.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 import numpy.random
 
-from lir.config.base import config_parser, pop_field, ContextAwareDict
+from lir.config.base import ContextAwareDict, config_parser, pop_field
 from lir.data.models import DataSet
 from lir.lrsystems.lrsystems import FeatureData
 
@@ -54,9 +54,9 @@ class SynthesizedNormalBinaryData(DataSet):
 @config_parser
 def synthesized_normal_binary(config: ContextAwareDict, _: Path) -> DataSet:
     """Set up (binary class) data source class to obtain normally distributed data from configuration."""
-    seed = pop_field(config, "seed")
-    h1 = pop_field(config, "h1")
-    h2 = pop_field(config, "h2")
+    seed = pop_field(config, 'seed')
+    h1 = pop_field(config, 'h1')
+    h2 = pop_field(config, 'h2')
     data_classes = {
         1: SynthesizedNormalDataClass(**h1),
         0: SynthesizedNormalDataClass(**h2),

--- a/lir/data/datasets/synthesized_normal_multiclass.py
+++ b/lir/data/datasets/synthesized_normal_multiclass.py
@@ -63,22 +63,22 @@ class SynthesizedNormalMulticlassData(DataSet):
 @config_parser
 def synthesized_normal_multiclass(config: ContextAwareDict, _: Path) -> DataSet:
     """Set up (multiple class) data source class to obtain normally distributed data from configuration."""
-    seed = pop_field(config, "seed", validate=int, required=False)
+    seed = pop_field(config, 'seed', validate=int, required=False)
 
-    population = pop_field(config, "population")
-    population_size = pop_field(population, "size", validate=int)
+    population = pop_field(config, 'population')
+    population_size = pop_field(population, 'size', validate=int)
     instances_per_source = pop_field(
         population,
-        "instances_per_source",
+        'instances_per_source',
         validate=int,
     )
 
-    dimensions_cfg = pop_field(config, "dimensions")
+    dimensions_cfg = pop_field(config, 'dimensions')
     dimensions = []
     for dim in dimensions_cfg:
-        mean = pop_field(dim, "mean", validate=float)
-        std = pop_field(dim, "std", validate=float)
-        error_std = pop_field(dim, "error_std", validate=float)
+        mean = pop_field(dim, 'mean', validate=float)
+        std = pop_field(dim, 'std', validate=float)
+        error_std = pop_field(dim, 'error_std', validate=float)
         dimensions.append(SynthesizedDimension(mean, std, error_std))
 
     return SynthesizedNormalMulticlassData(

--- a/lir/data/io.py
+++ b/lir/data/io.py
@@ -3,6 +3,7 @@ import urllib.request
 from pathlib import Path
 from typing import IO, Any
 
+
 LOG = logging.getLogger(__name__)
 
 
@@ -11,12 +12,12 @@ class RemoteResource:
         self.url = url
         self.local_directory = local_directory
 
-    def open(self, filename: str, mode: str = "r") -> IO[Any]:
+    def open(self, filename: str, mode: str = 'r') -> IO[Any]:
         local_path = self.local_directory / filename
         if not local_path.exists():
-            url = f"{self.url}/{filename}"
+            url = f'{self.url}/{filename}'
             local_path.parent.mkdir(exist_ok=True, parents=True)
             urllib.request.urlretrieve(url, local_path)
 
-        LOG.debug(f"open file: {local_path}")
+        LOG.debug(f'open file: {local_path}')
         return open(local_path, mode)

--- a/lir/experiment.py
+++ b/lir/experiment.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence, Callable
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 
 from tqdm import tqdm
@@ -8,7 +8,8 @@ from tqdm import tqdm
 import lir
 from lir.aggregation import Aggregation
 from lir.data.models import DataStrategy, concatenate_instances
-from lir.lrsystems.lrsystems import LRSystem, LLRData
+from lir.lrsystems.lrsystems import LLRData, LRSystem
+
 
 LOG = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class Experiment(ABC):
         # Generate visualization output as configured by `visualization_functions`
         # and write graphical output to the `output_path`.
         output_dir = self.output_path / lrsystem.name
-        LOG.debug(f"writing visualizations to {output_dir}")
+        LOG.debug(f'writing visualizations to {output_dir}')
         for visualization_function in self.visualization_functions:
             visualization_function(output_dir, llrs, labels)
 

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -11,7 +11,7 @@ class LRSystem(ABC):
         self.name = name
         self.parameters: dict[str, Any] = {}
 
-    def fit(self, instances: FeatureData) -> "LRSystem":
+    def fit(self, instances: FeatureData) -> 'LRSystem':
         """
         Fits the LR system on a set of features and corresponding labels.
 

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,4 +1,4 @@
-from lir.lrsystems.lrsystems import LRSystem, LLRData, FeatureData
+from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
 from lir.transform.pairing import PairingMethod
 from lir.transform.pipeline import Pipeline
 
@@ -24,7 +24,7 @@ class ScoreBasedSystem(LRSystem):
         self.pairing_function = pairing_function
         self.evaluation_pipeline = evaluation_pipeline or Pipeline([])
 
-    def fit(self, instances: FeatureData) -> "LRSystem":
+    def fit(self, instances: FeatureData) -> 'LRSystem':
         instances = self.preprocessing_pipeline.fit_transform(instances)
         pairs = self.pairing_function.pair(instances, 1, 1)
         self.evaluation_pipeline.fit(pairs)
@@ -39,7 +39,7 @@ class ScoreBasedSystem(LRSystem):
         relation between input and output data.
         """
         if not instances.has_labels:
-            raise ValueError("pairing requires labels")
+            raise ValueError('pairing requires labels')
 
         instances = self.preprocessing_pipeline.transform(instances)
         pairs = self.pairing_function.pair(instances, 1, 1)

--- a/lir/lrsystems/specific_source.py
+++ b/lir/lrsystems/specific_source.py
@@ -1,4 +1,4 @@
-from lir.lrsystems.lrsystems import LRSystem, LLRData, FeatureData
+from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
 from lir.transform.pipeline import Pipeline
 
 
@@ -14,7 +14,7 @@ class SpecificSourceSystem(LRSystem):
         super().__init__(name)
         self.pipeline = pipeline
 
-    def fit(self, instances: FeatureData) -> "LRSystem":
+    def fit(self, instances: FeatureData) -> 'LRSystem':
         self.pipeline.fit(instances)
         return self
 

--- a/lir/main.py
+++ b/lir/main.py
@@ -11,6 +11,7 @@ from lir import registry
 from lir.config.base import YamlParseError
 from lir.config.experiment_strategies import parse_experiments_setup
 
+
 LOG = logging.getLogger(__file__)
 DEFAULT_LOGLEVEL = logging.WARNING
 
@@ -25,7 +26,7 @@ def setup_logging(file_path: str, level_increase: int) -> None:
     loglevel = max(logging.DEBUG, min(logging.CRITICAL, DEFAULT_LOGLEVEL - level_increase * 10))
 
     # setup formatter
-    log_format = "[%(asctime)-15s %(levelname)s] %(name)s: %(message)s"
+    log_format = '[%(asctime)-15s %(levelname)s] %(name)s: %(message)s'
     fmt = logging.Formatter(log_format)
 
     ch = logging.StreamHandler()
@@ -33,55 +34,55 @@ def setup_logging(file_path: str, level_increase: int) -> None:
     ch.setLevel(loglevel)
     logging.getLogger().addHandler(ch)
 
-    logging.getLogger("").setLevel(logging.DEBUG)
+    logging.getLogger('').setLevel(logging.DEBUG)
 
 
 def initialize_logfile(output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    fh = logging.FileHandler(output_dir / "log.txt")
-    fh.setFormatter(logging.Formatter("[%(asctime)-15s %(levelname)s] %(name)s: %(message)s"))
+    fh = logging.FileHandler(output_dir / 'log.txt')
+    fh.setFormatter(logging.Formatter('[%(asctime)-15s %(levelname)s] %(name)s: %(message)s'))
     fh.setLevel(logging.DEBUG)
     logging.getLogger().addHandler(fh)
 
 
 def error(msg: str) -> None:
-    sys.stderr.write(f"{msg}\n")
+    sys.stderr.write(f'{msg}\n')
     if LOG.level <= logging.DEBUG:
         raise
     sys.exit(1)
 
 
 def main() -> None:
-    app_name = "benchmark"
+    app_name = 'benchmark'
 
-    parser = argparse.ArgumentParser(description="Run all or some of the parts of project")
+    parser = argparse.ArgumentParser(description='Run all or some of the parts of project')
 
     parser.add_argument(
-        "setup",
-        metavar="FILENAME",
-        help="path to YAML file describing the evaluation setup",
+        'setup',
+        metavar='FILENAME',
+        help='path to YAML file describing the evaluation setup',
     )
     parser.add_argument(
-        "--experiment",
-        help="run a specific experiment (defaults to all experiments)",
-        nargs="*",
+        '--experiment',
+        help='run a specific experiment (defaults to all experiments)',
+        nargs='*',
     )
     parser.add_argument(
-        "--list-experiments",
-        help="prints a list of configured experiments",
-        action="store_true",
+        '--list-experiments',
+        help='prints a list of configured experiments',
+        action='store_true',
     )
     parser.add_argument(
-        "--list-registry",
-        help="prints a list of registered components",
-        action="store_true",
+        '--list-registry',
+        help='prints a list of registered components',
+        action='store_true',
     )
 
-    parser.add_argument("-v", help="increases verbosity", action="count", default=0)
-    parser.add_argument("-q", help="decreases verbosity", action="count", default=0)
+    parser.add_argument('-v', help='increases verbosity', action='count', default=0)
+    parser.add_argument('-q', help='decreases verbosity', action='count', default=0)
     args = parser.parse_args()
 
-    setup_logging(f"{app_name}.log", args.v - args.q)
+    setup_logging(f'{app_name}.log', args.v - args.q)
 
     if args.list_registry:
         for name in registry.registry():
@@ -91,13 +92,13 @@ def main() -> None:
     try:
         experiments, output_dir = parse_experiments_setup(confidence.loadf(args.setup))
     except YamlParseError as e:
-        error(f"error while parsing {args.setup}: {str(e)}")
+        error(f'error while parsing {args.setup}: {str(e)}')
         raise  # this statement is not reachable, but helps code validation
 
     initialize_logfile(output_dir)
 
     if args.list_experiments:
-        for name, experiment in experiments.items():
+        for name, _experiment in experiments.items():
             print(name)
         return
 
@@ -106,11 +107,11 @@ def main() -> None:
             if name in experiments:
                 experiments[name].run()
             else:
-                error(f"no such experiment: {name}")
+                error(f'no such experiment: {name}')
     else:
         for experiment in experiments.values():
             experiment.run()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/lir/metrics/__init__.py
+++ b/lir/metrics/__init__.py
@@ -22,7 +22,7 @@ def cllr(llrs: np.ndarray, y: np.ndarray, weights: tuple[float, float] = (1, 1))
     #   divide -> ignore divide by zero
     #   over -> ignore scalar overflow
     lrs = logodds_to_odds(llrs)
-    with np.errstate(divide="ignore", over="ignore"):
+    with np.errstate(divide='ignore', over='ignore'):
         lrs0, lrs1 = Xy_to_Xn(lrs, y)
         cllr0 = weights[0] * np.mean(np.log2(1 + lrs0)) if weights[0] > 0 else 0
         cllr1 = weights[1] * np.mean(np.log2(1 + 1 / lrs1)) if weights[1] > 0 else 0

--- a/lir/metrics/devpav.py
+++ b/lir/metrics/devpav.py
@@ -23,7 +23,7 @@ def _calcsurface(c1: tuple[float, float], c2: tuple[float, float]) -> float:
 
     elif a < 0:
         raise ValueError(
-            f"slope is negative; impossible for PAV-transform. Coordinates are {c1} and {c2}. Calculated slope is {a}"
+            f'slope is negative; impossible for PAV-transform. Coordinates are {c1} and {c2}. Calculated slope is {a}'
         )
     else:
         # than xs is finite:
@@ -65,7 +65,7 @@ def _calcsurface(c1: tuple[float, float], c2: tuple[float, float]) -> float:
                 # situation 4 of 4 : this situation should never appear. There is a fourth sibution as situation 3,
                 # but than above the identity line. However, this is impossible by definition of a
                 # PAV-transform (y2 > x1).
-                raise ValueError(f"unexpected coordinate combination: ({x1}, {y1}) and ({x2}, {y2})")
+                raise ValueError(f'unexpected coordinate combination: ({x1}, {y1}) and ({x2}, {y2})')
     return surface
 
 
@@ -132,7 +132,7 @@ def devpav(llrs: np.ndarray, y: np.ndarray) -> float:
     calculates devPAV for LR data under H1 and H2.
     """
     if all(y) or not any(y):
-        raise ValueError("devpav: illegal input: at least one value is required for each class")
+        raise ValueError('devpav: illegal input: at least one value is required for each class')
     cal = IsotonicCalibrator()
     pavllrs = cal.fit_transform(llrs, y)
     return _devpavcalculator(logodds_to_odds(llrs), logodds_to_odds(pavllrs), y)

--- a/lir/optuna.py
+++ b/lir/optuna.py
@@ -6,10 +6,10 @@ import optuna
 from lir.aggregation import Aggregation
 from lir.config.lrsystem_architectures import parse_augmented_lrsystem
 from lir.config.substitution import (
-    Hyperparameter,
-    FloatHyperparameter,
-    HyperparameterOption,
     ContextAwareDict,
+    FloatHyperparameter,
+    Hyperparameter,
+    HyperparameterOption,
 )
 from lir.data.models import DataStrategy
 from lir.experiment import Experiment
@@ -65,16 +65,16 @@ class OptunaExperiment(Experiment):
             self.baseline_config,
             assignments,
             self.output_path,
-            dirname_prefix=f"{trial.number:03d}__",
+            dirname_prefix=f'{trial.number:03d}__',
         )
 
         # add optuna values as system parameters
         lrsystem.parameters.update(
             {
                 # trial.number is a sequence number, starting at 0
-                "trial": trial.number,
+                'trial': trial.number,
                 # the best trial is known only at the second run, since the first trial results are not available yet
-                "best_trial": trial.study.best_trial.number if trial.number > 0 else "",
+                'best_trial': trial.study.best_trial.number if trial.number > 0 else '',
             }
         )
 

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -1,6 +1,6 @@
-from collections.abc import Iterator
 import logging
-from contextlib import contextmanager, _GeneratorContextManager
+from collections.abc import Iterator
+from contextlib import _GeneratorContextManager, contextmanager
 from functools import partial
 from os import PathLike
 from typing import Any
@@ -12,9 +12,11 @@ from matplotlib.axis import Axis
 
 from lir import util
 from lir.algorithms.bayeserror import plot_nbe as nbe
-from .expected_calibration_error import plot_ece as ece
+
 from ..algorithms.isotonic_regression import IsotonicCalibrator
 from ..transform import Transformer
+from .expected_calibration_error import plot_ece as ece
+
 
 LOG = logging.getLogger(__name__)
 
@@ -28,8 +30,8 @@ plt.get_ylim = lambda: plt.gca().get_ylim()
 plt.set_xticks = plt.xticks
 plt.set_yticks = plt.yticks
 
-H1_COLOR = "red"
-H2_COLOR = "blue"
+H1_COLOR = 'red'
+H2_COLOR = 'blue'
 
 
 class Canvas:
@@ -142,7 +144,7 @@ def pav(
     ]
 
     # plot line through origin
-    ax.plot(xrange, yrange, "--", color="gray", label="Optimal system")
+    ax.plot(xrange, yrange, '--', color='gray', label='Optimal system')
 
     # line pre pav llrs x and post pav llrs y
     line_x = np.arange(*xrange, 0.01)
@@ -154,7 +156,7 @@ def pav(
 
     # some values of line_y go beyond the yrange which is problematic when there are infinite values
     mask_out_of_range = np.logical_and(line_x >= yrange[0], line_x <= yrange[1])
-    ax.plot(line_x[mask_out_of_range], line_y[mask_out_of_range], color="black", label="PAV transform")
+    ax.plot(line_x[mask_out_of_range], line_y[mask_out_of_range], color='black', label='PAV transform')
 
     # add points for infinite values
     if np.logical_or(np.isinf(pav_llrs), np.isinf(llrs)).any():
@@ -171,12 +173,12 @@ def pav(
             if neg_inf:
                 axis_range[0] -= step_size
                 ticks = [axis_range[0]] + ticks
-                tick_labels = ["-∞"] + tick_labels
+                tick_labels = ['-∞'] + tick_labels
 
             if pos_inf:
                 axis_range[1] += step_size
                 ticks = ticks + [axis_range[1]]
-                tick_labels = tick_labels + ["+∞"]
+                tick_labels = tick_labels + ['+∞']
 
             return axis_range, ticks, tick_labels
 
@@ -205,7 +207,7 @@ def pav(
         ax.set_xticks(ticks_x, tick_labels_x)
 
         color = [H1_COLOR if i > 0 else H2_COLOR for i in y_inf]
-        ax.scatter(x_inf, y_inf, color=color, marker="|")
+        ax.scatter(x_inf, y_inf, color=color, marker='|')
 
     ax.axis(xrange + yrange)
     # pre-/post-calibrated lr fit
@@ -222,13 +224,13 @@ def pav(
         n_h1 = np.count_nonzero(y)
         n_h2 = len(y) - n_h1
 
-        ax.scatter(h1_llrs, h1_pav, facecolors=H1_COLOR, marker=2, linewidths=1, alpha=0.5, label=f"H1 (n={n_h1})")
-        ax.scatter(h2_llrs, h2_pav, facecolors=H2_COLOR, marker=3, linewidths=1, alpha=0.5, label=f"H2 (n={n_h2})")
+        ax.scatter(h1_llrs, h1_pav, facecolors=H1_COLOR, marker=2, linewidths=1, alpha=0.5, label=f'H1 (n={n_h1})')
+        ax.scatter(h2_llrs, h2_pav, facecolors=H2_COLOR, marker=3, linewidths=1, alpha=0.5, label=f'H2 (n={n_h2})')
 
         # scatter plot of measured lrs
 
-    ax.set_xlabel("pre-calibrated log$_{10}$(LR)")
-    ax.set_ylabel("post-calibrated log$_{10}$(LR)")
+    ax.set_xlabel('pre-calibrated log$_{10}$(LR)')
+    ax.set_ylabel('post-calibrated log$_{10}$(LR)')
     ax.legend()
 
 
@@ -256,8 +258,8 @@ def lr_histogram(
     weights0, weights1 = (np.ones_like(points) / len(points) if weighted else None for points in (points0, points1))
     ax.hist(points1, bins=bins, alpha=0.25, weights=weights1)
     ax.hist(points0, bins=bins, alpha=0.25, weights=weights0)
-    ax.set_xlabel("log$_{10}$(LR)")
-    ax.set_ylabel("count" if not weighted else "relative frequency")
+    ax.set_xlabel('log$_{10}$(LR)')
+    ax.set_ylabel('count' if not weighted else 'relative frequency')
 
 
 def tippett(llrs: np.ndarray, y: np.ndarray, plot_type: int = 1, ax: Axes = plt) -> None:
@@ -284,13 +286,13 @@ def tippett(llrs: np.ndarray, y: np.ndarray, plot_type: int = 1, ax: Axes = plt)
     elif plot_type == 2:
         perc1 = (sum(i <= xplot1 for i in lr_1) / len(lr_1)) * 100
     else:
-        raise ValueError("plot_type must be either 1 or 2.")
+        raise ValueError('plot_type must be either 1 or 2.')
 
-    ax.plot(xplot1, perc1, color="b", label=r"LRs given $\mathregular{H_1}$")
-    ax.plot(xplot0, perc0, color="r", label=r"LRs given $\mathregular{H_2}$")
-    ax.axvline(x=0, color="k", linestyle="--")
-    ax.set_xlabel("log$_{10}$(LR)")
-    ax.set_ylabel("Cumulative proportion")
+    ax.plot(xplot1, perc1, color='b', label=r'LRs given $\mathregular{H_1}$')
+    ax.plot(xplot0, perc0, color='r', label=r'LRs given $\mathregular{H_2}$')
+    ax.axvline(x=0, color='k', linestyle='--')
+    ax.set_xlabel('log$_{10}$(LR)')
+    ax.set_ylabel('Cumulative proportion')
     ax.legend()
 
 
@@ -320,7 +322,7 @@ def score_distribution(
     """
     if ax is None:
         _, ax = plt.subplots()
-    plt.rcParams.update({"font.size": 15})
+    plt.rcParams.update({'font.size': 15})
 
     bins = np.histogram_bin_edges(scores[np.isfinite(scores)], bins=bins)
     bin_width = bins[1] - bins[0]
@@ -336,8 +338,8 @@ def score_distribution(
 
     # handle inf values
     if np.isinf(scores).any():
-        prop_cycle = plt.rcParams["axes.prop_cycle"]
-        colors = prop_cycle.by_key()["color"]
+        prop_cycle = plt.rcParams['axes.prop_cycle']
+        colors = prop_cycle.by_key()['color']
         x_range = np.linspace(min(bins), max(bins), 6).tolist()
         labels = [str(round(tick, 1)) for tick in x_range]
         step_size = x_range[2] - x_range[1]
@@ -346,7 +348,7 @@ def score_distribution(
 
         if np.isneginf(scores).any():
             x_range = [x_range[0] - step_size] + x_range
-            labels = ["-∞"] + labels
+            labels = ['-∞'] + labels
             for i, s in enumerate(scores_by_class):
                 if np.isneginf(s).any():
                     plot_args_inf.append(
@@ -359,7 +361,7 @@ def score_distribution(
 
         if np.isposinf(scores).any():
             x_range = x_range + [x_range[-1] + step_size]
-            labels.append("∞")
+            labels.append('∞')
             for i, s in enumerate(scores_by_class):
                 if np.isposinf(s).any():
                     plot_args_inf.append(
@@ -373,22 +375,22 @@ def score_distribution(
         ax.set_xticks(x_range, labels)
 
         for color, x_coord, y_coord in plot_args_inf:
-            ax.bar(x_coord, y_coord, width=bar_width, color=color, alpha=0.3, hatch="/")
+            ax.bar(x_coord, y_coord, width=bar_width, color=color, alpha=0.3, hatch='/')
 
-    for cls, weight in zip(y_classes, weights):
+    for cls, weight in zip(y_classes, weights, strict=True):
         ax.hist(
             scores[y == cls],
             bins=bins,
             alpha=0.3,
-            label=f"class {cls}",
+            label=f'class {cls}',
             weights=weight / bin_width if weighted else None,
         )
 
-        ax.set_xlabel("score")
+        ax.set_xlabel('score')
     if weighted:
-        ax.set_ylabel("probability density")
+        ax.set_ylabel('probability density')
     else:
-        ax.set_ylabel("count")
+        ax.set_ylabel('count')
 
 
 def calibrator_fit(
@@ -405,10 +407,10 @@ def calibrator_fit(
     """
     if ax is None:
         _, ax = plt.subplots()
-    plt.rcParams.update({"font.size": 15})
+    plt.rcParams.update({'font.size': 15})
 
     x = np.linspace(score_range[0], score_range[1], resolution)
     calibrator.transform(x)
 
-    ax.plot(x, calibrator.p1, color="tab:blue", label="fit class 1")
-    ax.plot(x, calibrator.p0, color="tab:orange", label="fit class 0")
+    ax.plot(x, calibrator.p1, color='tab:blue', label='fit class 1')
+    ax.plot(x, calibrator.p0, color='tab:orange', label='fit class 0')

--- a/lir/plotting/expected_calibration_error.py
+++ b/lir/plotting/expected_calibration_error.py
@@ -20,8 +20,8 @@ import numpy as np
 
 from lir.algorithms.isotonic_regression import IsotonicCalibrator
 from lir.util import (
-    odds_to_probability,
     logodds_to_odds,
+    odds_to_probability,
     probability_to_odds,
 )
 
@@ -52,16 +52,16 @@ def plot_ece(llrs, labels, log_prior_odds_range=None, ax=plt):
     ax.plot(
         log_prior_odds,
         calculate_ece(np.ones(len(labels)), labels, odds_to_probability(prior_odds)),
-        linestyle=":",
-        label="reference",
+        linestyle=':',
+        label='reference',
     )
 
     # plot LRs
     ax.plot(
         log_prior_odds,
         calculate_ece(logodds_to_odds(llrs), labels, odds_to_probability(prior_odds)),
-        linestyle="-",
-        label="LRs",
+        linestyle='-',
+        label='LRs',
     )
 
     # plot PAV LRs
@@ -69,16 +69,16 @@ def plot_ece(llrs, labels, log_prior_odds_range=None, ax=plt):
     ax.plot(
         log_prior_odds,
         calculate_ece(logodds_to_odds(pav_llrs), labels, odds_to_probability(prior_odds)),
-        linestyle="--",
-        label="PAV LRs",
+        linestyle='--',
+        label='PAV LRs',
     )
 
-    ax.set_xlabel("prior log$_{10}$(odds)")
-    ax.set_ylabel("empirical cross-entropy")
+    ax.set_xlabel('prior log$_{10}$(odds)')
+    ax.set_ylabel('empirical cross-entropy')
     ax.set_ylim((0, None))
     ax.set_xlim(log_prior_odds_range)
     ax.legend()
-    ax.grid(True, linestyle=":")
+    ax.grid(True, linestyle=':')
 
 
 def calculate_ece(lrs, y, priors):
@@ -95,14 +95,14 @@ def calculate_ece(lrs, y, priors):
         from class 1 (values in range [0..1])
     :returns: an array of entropy values of the same length as `priors`
     """
-    assert np.all(lrs >= 0), "invalid input for LR values"
-    assert np.all(np.unique(y) == np.array([0, 1])), "label set must be [0, 1]"
+    assert np.all(lrs >= 0), 'invalid input for LR values'
+    assert np.all(np.unique(y) == np.array([0, 1])), 'label set must be [0, 1]'
 
     prior_odds = np.repeat(probability_to_odds(priors), len(lrs)).reshape((len(priors), len(lrs)))
     posterior_odds = prior_odds * lrs
     posterior_p = odds_to_probability(posterior_odds)
 
-    with np.errstate(divide="ignore"):
+    with np.errstate(divide='ignore'):
         ece0 = -(1 - priors.reshape((len(priors), 1))) * np.log2(1 - posterior_p[:, y == 0])
         ece1 = -priors.reshape((len(priors), 1)) * np.log2(posterior_p[:, y == 1])
 

--- a/lir/transform/pairing.py
+++ b/lir/transform/pairing.py
@@ -53,7 +53,7 @@ class LegacyPairingMethod(ABC):
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
     ) -> PairedFeatureData:
-        meta = instances.meta if hasattr(instances, "meta") else np.zeros((instances.features.shape[0], 0))
+        meta = instances.meta if hasattr(instances, 'meta') else np.zeros((instances.features.shape[0], 0))
         pair_features, pair_labels, pair_meta = self._pair_arrays(
             instances.features, instances.labels, meta, n_trace_instances, n_ref_instances
         )
@@ -374,9 +374,9 @@ class InstancePairing(LegacyPairingMethod):
         assert features.shape[0] == meta.shape[0]
 
         if n_trace_instances != 1:
-            raise ValueError(f"invalid values for `n_trace_instances`; expected: 1; found: {n_trace_instances}")
+            raise ValueError(f'invalid values for `n_trace_instances`; expected: 1; found: {n_trace_instances}')
         if n_ref_instances != 1:
-            raise ValueError(f"invalid values for `n_ref_instances`; expected: 1; found: {n_ref_instances}")
+            raise ValueError(f'invalid values for `n_ref_instances`; expected: 1; found: {n_ref_instances}')
 
         pair_features, pair_labels = self._transform(features, labels)
         pair_features = pair_features.transpose(0, 2, 1)

--- a/lir/transform/pipeline.py
+++ b/lir/transform/pipeline.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from lir.data.models import FeatureData, FeatureDataType
-from lir.transform import as_transformer, Transformer
+from lir.transform import Transformer, as_transformer
 
 
 class Pipeline(Transformer):
@@ -19,8 +19,8 @@ class Pipeline(Transformer):
         """
         self.steps = [(name, as_transformer(module)) for name, module in steps]
 
-    def fit(self, instances: FeatureData) -> "Pipeline":
-        for name, module in self.steps[:-1]:
+    def fit(self, instances: FeatureData) -> 'Pipeline':
+        for _name, module in self.steps[:-1]:
             instances = module.fit_transform(instances)
 
         if len(self.steps) > 0:
@@ -30,11 +30,11 @@ class Pipeline(Transformer):
         return self
 
     def transform(self, instances: FeatureDataType) -> FeatureDataType:
-        for name, module in self.steps:
+        for _name, module in self.steps:
             instances = module.transform(instances)
         return instances
 
     def fit_transform(self, instances: FeatureData) -> FeatureData:
-        for name, module in self.steps:
+        for _name, module in self.steps:
             instances = module.fit_transform(instances)
         return instances

--- a/lir/util.py
+++ b/lir/util.py
@@ -1,18 +1,19 @@
 import collections
 import inspect
+import warnings
+from functools import partial
 from typing import Any, TypeVar
 
 import numpy as np
-import warnings
-from functools import partial
 
-LR = collections.namedtuple("LR", ["lr", "p0", "p1"])
+
+LR = collections.namedtuple('LR', ['lr', 'p0', 'p1'])
 
 
 def get_classes_from_Xy(X: np.ndarray, y: np.ndarray, classes: list[Any] | None = None) -> np.ndarray:
-    assert len(X.shape) >= 1, f"expected: X has at least 1 dimensions; found: {len(X.shape)} dimensions"
-    assert len(y.shape) == 1, f"expected: y is a 1-dimensional array; found: {len(y.shape)} dimensions"
-    assert X.shape[0] == y.size, f"dimensions of X and y do not match; found: {X.shape[0]} != {y.size}"
+    assert len(X.shape) >= 1, f'expected: X has at least 1 dimensions; found: {len(X.shape)} dimensions'
+    assert len(y.shape) == 1, f'expected: y is a 1-dimensional array; found: {len(y.shape)} dimensions'
+    assert X.shape[0] == y.size, f'dimensions of X and y do not match; found: {X.shape[0]} != {y.size}'
 
     return np.unique(y) if classes is None else np.asarray(classes)
 
@@ -45,7 +46,7 @@ def Xy_to_Xn(X: np.ndarray, y: np.ndarray, classes: list[int] | None = None) -> 
     return [X[y == yvalue] for yvalue in classes]
 
 
-FloatOrArray = TypeVar("FloatOrArray", np.ndarray, float)
+FloatOrArray = TypeVar('FloatOrArray', np.ndarray, float)
 
 
 def odds_to_probability(odds: FloatOrArray) -> FloatOrArray:
@@ -58,7 +59,7 @@ def odds_to_probability(odds: FloatOrArray) -> FloatOrArray:
        odds / (1 + odds), otherwise
     """
     inf_values = odds == np.inf
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid='ignore'):
         p = np.divide(odds, (1 + odds))
     p[inf_values] = 1
     return p
@@ -68,7 +69,7 @@ def probability_to_odds(p: FloatOrArray) -> FloatOrArray:
     """
     Converts a probability to odds
     """
-    with np.errstate(divide="ignore"):
+    with np.errstate(divide='ignore'):
         return p / (1 - p)
 
 
@@ -76,7 +77,7 @@ def probability_to_logodds(p: FloatOrArray) -> FloatOrArray:
     """
     Converts probability values to their log odds with base 10.
     """
-    with np.errstate(divide="ignore"):
+    with np.errstate(divide='ignore'):
         complement = 1 - p
         return np.log10(p) - np.log10(complement)
 
@@ -86,7 +87,7 @@ def logodds_to_probability(log_odds: FloatOrArray) -> FloatOrArray:
 
 
 def logodds_to_odds(log_odds: FloatOrArray) -> FloatOrArray:
-    with np.errstate(divide="ignore"):
+    with np.errstate(divide='ignore'):
         return 10**log_odds
 
 
@@ -100,8 +101,9 @@ def ln_to_log10(ln_data: FloatOrArray) -> FloatOrArray:
 
 def warn_deprecated() -> None:
     warnings.warn(
-        f"the function `{inspect.stack()[1].function}` is no longer maintained; "
-        "please check documentation for alternatives"
+        f'the function `{inspect.stack()[1].function}` is no longer maintained; '
+        'please check documentation for alternatives',
+        stacklevel=2,
     )
 
 
@@ -125,10 +127,10 @@ def check_misleading_finite(values: np.ndarray, labels: np.ndarray) -> None:
 
     # give error message if H1's contain zeros and H2's contain ones
     if np.any(np.isneginf(values[labels == 1])) and np.any(np.isposinf(values[labels == 0])):
-        raise ValueError("invalid input: -inf found for H1 and inf found for H2")
+        raise ValueError('invalid input: -inf found for H1 and inf found for H2')
     # give error message if H1's contain zeros
     if np.any(np.isneginf(values[labels == 1])):
-        raise ValueError("invalid input: -inf found for H1")
+        raise ValueError('invalid input: -inf found for H1')
     # give error message if H2's contain ones
     if np.any(np.isposinf(values[labels == 0])):
-        raise ValueError("invalid input: inf found for H2")
+        raise ValueError('invalid input: inf found for H2')

--- a/lir/visualization.py
+++ b/lir/visualization.py
@@ -8,7 +8,7 @@ from lir.plotting import savefig
 def pav(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
     """Helper function to generate and save a PAV-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
-    path = base_path / "pav.png"
+    path = base_path / 'pav.png'
     with savefig(str(path)) as fig:
         fig.pav(llrs, labels)
 
@@ -16,7 +16,7 @@ def pav(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
 def ece(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
     """Helper function to generate and save an ECE-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
-    path = base_path / "ece.png"
+    path = base_path / 'ece.png'
     with savefig(str(path)) as fig:
         fig.ece(llrs, labels)
 
@@ -24,6 +24,6 @@ def ece(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
 def lr_histogram(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
     """Helper function to generate and save an histogram-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
-    path = base_path / "histogram.png"
+    path = base_path / 'histogram.png'
     with savefig(str(path)) as fig:
         fig.lr_histogram(llrs, labels)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:69991842d975fca58aba33f8aae024c9d40502bb35427f647edccfda39ac3b1f"
+content_hash = "sha256:9755389416727ed5cbe09bcdb6992a5d49047ba8b2797d4a2cd991eb71fcf99f"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -1321,6 +1321,34 @@ files = [
     {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
     {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.3"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter and code formatter, written in Rust."
+groups = ["dev"]
+files = [
+    {file = "ruff-0.14.3-py3-none-linux_armv6l.whl", hash = "sha256:876b21e6c824f519446715c1342b8e60f97f93264012de9d8d10314f8a79c371"},
+    {file = "ruff-0.14.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b6fd8c79b457bedd2abf2702b9b472147cd860ed7855c73a5247fa55c9117654"},
+    {file = "ruff-0.14.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:71ff6edca490c308f083156938c0c1a66907151263c4abdcb588602c6e696a14"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:786ee3ce6139772ff9272aaf43296d975c0217ee1b97538a98171bf0d21f87ed"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cd6291d0061811c52b8e392f946889916757610d45d004e41140d81fb6cd5ddc"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a497ec0c3d2c88561b6d90f9c29f5ae68221ac00d471f306fa21fa4264ce5fcd"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e231e1be58fc568950a04fbe6887c8e4b85310e7889727e2b81db205c45059eb"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:469e35872a09c0e45fecf48dd960bfbce056b5db2d5e6b50eca329b4f853ae20"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d6bc90307c469cb9d28b7cfad90aaa600b10d67c6e22026869f585e1e8a2db0"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2f8a0bbcffcfd895df39c9a4ecd59bb80dca03dc43f7fb63e647ed176b741e"},
+    {file = "ruff-0.14.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:678fdd7c7d2d94851597c23ee6336d25f9930b460b55f8598e011b57c74fd8c5"},
+    {file = "ruff-0.14.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1ec1ac071e7e37e0221d2f2dbaf90897a988c531a8592a6a5959f0603a1ecf5e"},
+    {file = "ruff-0.14.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afcdc4b5335ef440d19e7df9e8ae2ad9f749352190e96d481dc501b753f0733e"},
+    {file = "ruff-0.14.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7bfc42f81862749a7136267a343990f865e71fe2f99cf8d2958f684d23ce3dfa"},
+    {file = "ruff-0.14.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a65e448cfd7e9c59fae8cf37f9221585d3354febaad9a07f29158af1528e165f"},
+    {file = "ruff-0.14.3-py3-none-win32.whl", hash = "sha256:f3d91857d023ba93e14ed2d462ab62c3428f9bbf2b4fbac50a03ca66d31991f7"},
+    {file = "ruff-0.14.3-py3-none-win_amd64.whl", hash = "sha256:d7b7006ac0756306db212fd37116cce2bd307e1e109375e1c6c106002df0ae5f"},
+    {file = "ruff-0.14.3-py3-none-win_arm64.whl", hash = "sha256:26eb477ede6d399d898791d01961e16b86f02bc2486d0d1a7a9bb2379d055dc1"},
+    {file = "ruff-0.14.3.tar.gz", hash = "sha256:4ff876d2ab2b161b6de0aa1f5bd714e8e9b4033dc122ee006925fbacc4f62153"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:bfbdf40ba481006a94cb2803981da4f49c67f156142b234caffcb9c5a0e4e12c"
+content_hash = "sha256:69991842d975fca58aba33f8aae024c9d40502bb35427f647edccfda39ac3b1f"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -725,7 +725,7 @@ name = "mypy"
 version = "1.18.2"
 requires_python = ">=3.9"
 summary = "Optional static typing for Python"
-groups = ["default"]
+groups = ["dev"]
 dependencies = [
     "mypy-extensions>=1.0.0",
     "pathspec>=0.9.0",
@@ -733,12 +733,6 @@ dependencies = [
     "typing-extensions>=4.6.0",
 ]
 files = [
-    {file = "mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c"},
-    {file = "mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e"},
-    {file = "mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b"},
-    {file = "mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66"},
-    {file = "mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428"},
-    {file = "mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed"},
     {file = "mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f"},
     {file = "mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341"},
     {file = "mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d"},
@@ -772,7 +766,7 @@ name = "mypy-extensions"
 version = "1.1.0"
 requires_python = ">=3.8"
 summary = "Type system extensions for programs checked with the mypy type checker."
-groups = ["default"]
+groups = ["dev"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -955,7 +949,7 @@ name = "pathspec"
 version = "0.12.1"
 requires_python = ">=3.8"
 summary = "Utility library for gitignore style pattern matching of file paths."
-groups = ["default"]
+groups = ["dev"]
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
@@ -1533,7 +1527,7 @@ name = "typing-extensions"
 version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8eb9bcae8dc97ef862d6c07715b8a8aa8d52d01143881dd436b2ab6f9036b692"
+content_hash = "sha256:bfbdf40ba481006a94cb2803981da4f49c67f156142b234caffcb9c5a0e4e12c"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -39,57 +39,6 @@ dependencies = [
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
-]
-
-[[package]]
-name = "black"
-version = "25.9.0"
-requires_python = ">=3.9"
-summary = "The uncompromising code formatter."
-groups = ["default"]
-dependencies = [
-    "click>=8.0.0",
-    "mypy-extensions>=0.4.3",
-    "packaging>=22.0",
-    "pathspec>=0.9.0",
-    "platformdirs>=2",
-    "pytokens>=0.1.10",
-    "tomli>=1.1.0; python_version < \"3.11\"",
-    "typing-extensions>=4.0.1; python_version < \"3.11\"",
-]
-files = [
-    {file = "black-25.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7"},
-    {file = "black-25.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92"},
-    {file = "black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713"},
-    {file = "black-25.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1"},
-    {file = "black-25.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa"},
-    {file = "black-25.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d"},
-    {file = "black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608"},
-    {file = "black-25.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f"},
-    {file = "black-25.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0"},
-    {file = "black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4"},
-    {file = "black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e"},
-    {file = "black-25.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a"},
-    {file = "black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175"},
-    {file = "black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f"},
-    {file = "black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831"},
-    {file = "black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357"},
-    {file = "black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae"},
-    {file = "black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619"},
-]
-
-[[package]]
-name = "click"
-version = "8.3.0"
-requires_python = ">=3.10"
-summary = "Composable command line interface toolkit"
-groups = ["default"]
-dependencies = [
-    "colorama; platform_system == \"Windows\"",
-]
-files = [
-    {file = "click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"},
-    {file = "click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"},
 ]
 
 [[package]]
@@ -311,37 +260,6 @@ groups = ["default"]
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-requires_python = ">=3.9"
-summary = "the modular source code checker: pep8 pyflakes and co"
-groups = ["dev"]
-dependencies = [
-    "mccabe<0.8.0,>=0.7.0",
-    "pycodestyle<2.15.0,>=2.14.0",
-    "pyflakes<3.5.0,>=3.4.0",
-]
-files = [
-    {file = "flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e"},
-    {file = "flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"},
-]
-
-[[package]]
-name = "flake8-pyproject"
-version = "1.2.3"
-requires_python = ">= 3.6"
-summary = "Flake8 plug-in loading the configuration from pyproject.toml"
-groups = ["dev"]
-dependencies = [
-    "Flake8>=5",
-    "TOMLi; python_version < \"3.11\"",
-    "TOMLi<2; python_version < \"3.7\"",
-]
-files = [
-    {file = "flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a"},
 ]
 
 [[package]]
@@ -803,17 +721,6 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-requires_python = ">=3.6"
-summary = "McCabe checker, plugin for flake8"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mypy"
 version = "1.18.2"
 requires_python = ">=3.9"
@@ -1155,17 +1062,6 @@ files = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.5.0"
-requires_python = ">=3.10"
-summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-groups = ["default"]
-files = [
-    {file = "platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3"},
-    {file = "platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312"},
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 requires_python = ">=3.9"
@@ -1174,17 +1070,6 @@ groups = ["dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-requires_python = ">=3.9"
-summary = "Python style guide checker"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
-    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
 ]
 
 [[package]]
@@ -1313,17 +1198,6 @@ files = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-requires_python = ">=3.9"
-summary = "passive checker of Python programs"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"},
-    {file = "pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58"},
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 requires_python = ">=3.8"
@@ -1377,17 +1251,6 @@ dependencies = [
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
-]
-
-[[package]]
-name = "pytokens"
-version = "0.2.0"
-requires_python = ">=3.8"
-summary = "A Fast, spec compliant Python 3.13+ tokenizer that runs on older Pythons."
-groups = ["default"]
-files = [
-    {file = "pytokens-0.2.0-py3-none-any.whl", hash = "sha256:74d4b318c67f4295c13782ddd9abcb7e297ec5630ad060eb90abf7ebbefe59f8"},
-    {file = "pytokens-0.2.0.tar.gz", hash = "sha256:532d6421364e5869ea57a9523bf385f02586d4662acbcc0342afd69511b4dd43"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "tqdm>=4.67.1",
     "scikit-learn>=1.2",
     "xgboost>=1.5",
-    "mypy>=1.14.1",
     "optuna>=4.4.0",
     "scipy>=1.13.1",
     "pandas>=2.3.2",
@@ -38,6 +37,7 @@ lir = "lir.main:main"
 dev = [
     "coverage",
     "pytest",
+    "mypy>=1.18.2",
 ]
 
 [tool.pdm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "lir"
 description = "Package for optimising and evaluating Likelihood Ratio (LR) systems."
 dynamic = ["version"]
 authors = [
-    {name = "Netherlands Forensics Institute", email = "netherlandsforensicinstitute@users.noreply.github.com"},
-]
+    {name = "Netherlands Forensics Institute", email = "netherlandsforensicinstitute@users.noreply.github.com"}, ]
 requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "Apache Software License 2.0"}
@@ -38,18 +37,46 @@ dev = [
     "coverage",
     "pytest",
     "mypy>=1.18.2",
+    "ruff>=0.14.3",
 ]
 
 [tool.pdm]
 version = {source = "scm"}
 
 [tool.pdm.scripts]
-all = {composite = ["check", "format-fix", "test"]}
-check = {composite = ["lint", "format-check", "mypy"]}
+all = {composite = ["check", "test"]}
+check = {composite = ["format-check", "lint", "mypy"]}
+fix = {composite = ["lint-fix", "format-fix"]}
+lint = "ruff check lir/"
+lint-fix = "ruff check --fix lir/"
+format-check = "ruff format --diff lir/"
+format-fix = "ruff format lir/"
 mypy = "mypy lir"
 test = "coverage run --branch --source lir --module pytest --strict-markers tests/"
 test-coverage = "coverage report"
 lir = "python run.py"
+
+[tool.ruff]
+format.quote-style = "single"
+line-length = 120
+lint.flake8-builtins.ignorelist = ["format"]
+lint.flake8-quotes.inline-quotes = "single"
+lint.ignore = [
+    # enforced by the formatter, not ignoring this causes warnings
+    "COM812",
+    # 'r' is the default mode for builtin open(), but explicit is better than implicit
+    "UP015",
+    # `X` as variable name is allowed to be uppercase in this project
+    "N802", "N803", "N806",
+    # allow `open()` over `Path.open()`
+    "PTH123",
+    # allow raising custom Exceptions in try/catch blocks
+    "B904",
+    # do not enforce use of all() inside `for()` loop
+    "SIM110",
+]
+lint.isort.lines-after-imports = 2
+lint.select = ["A", "B", "COM", "C4", "DTZ", "E", "F", "I", "N", "PTH", "Q", "SIM", "UP"]
 
 [tool.mypy]
 # allow redefinition of inferred / assigned types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "tqdm>=4.67.1",
     "scikit-learn>=1.2",
     "xgboost>=1.5",
-    "black>=24.8.0",
     "mypy>=1.14.1",
     "optuna>=4.4.0",
     "scipy>=1.13.1",
@@ -38,8 +37,6 @@ lir = "lir.main:main"
 [dependency-groups]
 dev = [
     "coverage",
-    "flake8",
-    "flake8-pyproject",
     "pytest",
 ]
 
@@ -49,18 +46,10 @@ version = {source = "scm"}
 [tool.pdm.scripts]
 all = {composite = ["check", "format-fix", "test"]}
 check = {composite = ["lint", "format-check", "mypy"]}
-lint = "flake8 lir/"
-format-check = "black --check lir --line-length 120"
-format-fix = "black lir --line-length 120"
 mypy = "mypy lir"
 test = "coverage run --branch --source lir --module pytest --strict-markers tests/"
 test-coverage = "coverage report"
 lir = "python run.py"
-
-[tool.flake8]
-max-line-length = 120
-application-import-names = ["lir"]
-import-order-style = "pycharm"
 
 [tool.mypy]
 # allow redefinition of inferred / assigned types

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -23,18 +23,21 @@ def test_instance_pairing_seed():
     instances = data.get_instances()
     instances_tuple = instances.features, instances.labels, np.ones((instances.labels.shape[0], 0))
     for values in zip(
-        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple)
+        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple),
+        strict=True
     ):
         assert np.all(values[0] == values[1])
 
     pairing0 = InstancePairing(seed=1, ratio_limit=1)
     pairing1 = InstancePairing(seed=1, ratio_limit=1)
     for values in zip(
-        pairing0._pair_arrays(*instances_tuple), pairing0._pair_arrays(*instances_tuple)
+        pairing0._pair_arrays(*instances_tuple), pairing0._pair_arrays(*instances_tuple),
+        strict=True
     ):
         assert np.all(values[0] == values[1])
     for values in zip(
-        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple)
+        pairing0._pair_arrays(*instances_tuple), pairing1._pair_arrays(*instances_tuple),
+        strict=True
     ):
         assert np.all(values[0] == values[1])
 


### PR DESCRIPTION
This patch replaces `flake8`, `black` with `ruff`. The configuration was mostly inherited from the standard we've discussed.

The `mypy` dependency has been moved to the `dev` dependencies as well.

As a lot of files have changed, due to the new style rules, it would be wise to review this PR by navigating through each commit separately.