### PR TITLE
Use testmon to only test changed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 /.pdm-build
 /.pdm-python
 /.python-version
+.testmondata

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:9755389416727ed5cbe09bcdb6992a5d49047ba8b2797d4a2cd991eb71fcf99f"
+content_hash = "sha256:848c3a597f6cd81bf648b2b54339da71df0badd34d2fae65bc524f03090d6190"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -1231,6 +1231,21 @@ dependencies = [
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.1.3"
+requires_python = ">=3.8"
+summary = "selects tests affected by changed files and methods"
+groups = ["dev"]
+dependencies = [
+    "coverage<8,>=6",
+    "pytest<9,>=5",
+]
+files = [
+    {file = "pytest_testmon-2.1.3-py3-none-any.whl", hash = "sha256:53ba06d8a90ce24c3a191b196aac72ca4b788beff5eb1c1bffee04dc50ec7105"},
+    {file = "pytest_testmon-2.1.3.tar.gz", hash = "sha256:dad41aa7d501d74571750da1abd3f6673b63fd9dbf3023bd1623814999018c97"},
 ]
 
 [[package]]

--- a/pre-commit.example
+++ b/pre-commit.example
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pdm run all
+pdm run all_with_quicktest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ version = {source = "scm"}
 
 [tool.pdm.scripts]
 all = {composite = ["check", "test"]}
+all_with_quicktest = {composite = ["check", "quicktest"]}
 check = {composite = ["format-check", "lint", "mypy"]}
 fix = {composite = ["lint-fix", "format-fix"]}
 lint = "ruff check lir/"
@@ -53,7 +54,9 @@ lint-fix = "ruff check --fix lir/"
 format-check = "ruff format --diff lir/"
 format-fix = "ruff format lir/"
 mypy = "mypy lir"
-test = "coverage run --branch --source lir --module pytest --strict-markers tests/ --testmon"
+# If no args are given to 'test', this will run as if '{args}' is an empty string.
+test = "coverage run --branch --source lir --module pytest --strict-markers tests/ {args}"
+quicktest = {composite = ["test --testmon"]}
 test-coverage = "coverage report"
 lir = "python run.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ lir = "lir.main:main"
 dev = [
     "coverage",
     "pytest",
+    "pytest-testmon>=2.1.3",
     "mypy>=1.18.2",
     "ruff>=0.14.3",
 ]
@@ -52,7 +53,7 @@ lint-fix = "ruff check --fix lir/"
 format-check = "ruff format --diff lir/"
 format-fix = "ruff format lir/"
 mypy = "mypy lir"
-test = "coverage run --branch --source lir --module pytest --strict-markers tests/"
+test = "coverage run --branch --source lir --module pytest --strict-markers tests/ --testmon"
 test-coverage = "coverage report"
 lir = "python run.py"
 


### PR DESCRIPTION
When running pre-commit, `pdm run all` runs all the `pytest` tests. By using `testmon`, it only runs the tests that touches files that have been changes. 


This should not break the tests on the server, as the first time testmon is used, it runs all the tests.