### PR TITLE
Use log10-base for LRs and step size; base range for threshold on dataset sizes.

### DIFF
--- a/lir/algorithms/bayeserror.py
+++ b/lir/algorithms/bayeserror.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from lir.bounding import LLRBounder
-from lir.util import logodds_to_odds, odds_to_logodds
+from lir.util import logodds_to_odds
 
 
 def plot_nbe(
@@ -67,7 +67,7 @@ def elub(
 
     # determine the range of LLRs to be considered, using dataset sizes: LB > -log10(size(Hp)+1), UB < log10(size(Hd)+1)
     llr_min = max((np.min(sanitized_llrs), -np.log10(np.sum(y) + 1)))
-    llr_max = min((np.max(sanitized_llrs), np.log10(np.sum(1-y) + 1)))
+    llr_max = min((np.max(sanitized_llrs), np.log10(np.sum(1 - y) + 1)))
     llr_steps_min = min(0, int(np.floor_divide(llr_min, step_size)))
     llr_steps_max = max(0, int((np.floor_divide(llr_max, step_size)) + 1))
     llr_threshold = np.linspace(llr_steps_min * step_size, llr_steps_max * step_size, llr_steps_max - llr_steps_min + 1)
@@ -157,5 +157,4 @@ class ELUBBounder(LLRBounder):
     """
 
     def calculate_bounds(self, llrs: np.ndarray, labels: np.ndarray) -> tuple[float | None, float | None]:
-        lower_lr_bound, upper_lr_bound = elub(llrs, labels, add_misleading=1)
-        return lower_lr_bound, upper_lr_bound
+        return elub(llrs, labels, add_misleading=1)

--- a/lir/algorithms/bayeserror.py
+++ b/lir/algorithms/bayeserror.py
@@ -41,50 +41,54 @@ def plot_nbe(
 
 
 def elub(
-    lrs: np.ndarray,
+    llrs: np.ndarray,
     y: np.ndarray,
     add_misleading: int = 1,
     step_size: float = 0.01,
-    substitute_extremes: tuple[float, float] = (np.exp(-20), np.exp(20)),
+    substitute_extremes: tuple[float, float] = (-9, 9),
 ) -> tuple[float, float]:
     """
-    Returns the empirical upper and lower bound LRs (ELUB LRs).
+    Returns the empirical upper and lower bound log10-LRs (ELUB LLRs).
 
-    :param lrs: an array of LRs
-    :param y: an array of ground-trugh labels (values 0 for Hd or 1 for Hp);
-        must be of the same length as `lrs`
-    :param add_misleading: the number of consequential misleading LRs to be added
+    :param llrs: an array of log10-LRs
+    :param y: an array of ground-truth labels (values 0 for Hd or 1 for Hp);
+        must be of the same length as `llrs`
+    :param add_misleading: the number of consequential misleading LLRs to be added
         to both sides (labels 0 and 1)
-    :param step_size: required accuracy on a natural logarithmic scale
+    :param step_size: required accuracy on a 10-base logarithmic scale
     :param substitute_extremes: tuple of scalars: substitute for extreme LRs, i.e.
         LRs of 0 and inf are substituted by these values
     """
 
-    # remove LRs of 0 and infinity
-    sanitized_lrs = lrs
-    sanitized_lrs[sanitized_lrs < substitute_extremes[0]] = substitute_extremes[0]
-    sanitized_lrs[sanitized_lrs > substitute_extremes[1]] = substitute_extremes[1]
+    # remove LLRs of -infinity and +infinity
+    sanitized_llrs = llrs
+    sanitized_llrs[sanitized_llrs < substitute_extremes[0]] = substitute_extremes[0]
+    sanitized_llrs[sanitized_llrs > substitute_extremes[1]] = substitute_extremes[1]
 
-    # determine the range of LRs to be considered
-    llrs = np.log(sanitized_lrs)
-    log_lr_threshold_range = (min(0, np.min(llrs)), max(0, np.max(llrs)) + step_size)
-    lr_threshold = np.exp(np.arange(*log_lr_threshold_range, step_size))
+    # determine the range of LLRs to be considered, using dataset sizes: LB > -log10(size(Hp)+1), UB < log10(size(Hd)+1)
+    llr_min = max((np.min(sanitized_llrs), -np.log10(np.sum(y) + 1)))
+    llr_max = min((np.max(sanitized_llrs), np.log10(np.sum(1-y) + 1)))
+    llr_steps_min = min(0, int(np.floor_divide(llr_min, step_size)))
+    llr_steps_max = max(0, int((np.floor_divide(llr_max, step_size)) + 1))
+    llr_threshold = np.linspace(llr_steps_min * step_size, llr_steps_max * step_size, llr_steps_max - llr_steps_min + 1)
 
-    eu_neutral = calculate_expected_utility(np.ones(len(sanitized_lrs)), y, lr_threshold)
-    eu_system = calculate_expected_utility(sanitized_lrs, y, lr_threshold, add_misleading)
+    # calculate the ratio of the expected utilities
+    eu_neutral = calculate_expected_utility(np.ones(len(sanitized_llrs)), y, 10**llr_threshold)
+    eu_system = calculate_expected_utility(10**sanitized_llrs, y, 10**llr_threshold, add_misleading)
     eu_ratio = eu_neutral / eu_system
 
-    # find threshold LRs which have utility ratio < 1 (only utility ratio >= 1 is acceptable)
-    eu_negative_left = lr_threshold[(lr_threshold <= 1) & (eu_ratio < 1)]
-    eu_negative_right = lr_threshold[(lr_threshold >= 1) & (eu_ratio < 1)]
+    # find threshold LLRs which have utility ratio < 1 (only utility ratio >= 1 is acceptable)
+    eu_negative_left = llr_threshold[(llr_threshold <= 0) & (eu_ratio < 1)]
+    eu_negative_right = llr_threshold[(llr_threshold >= 0) & (eu_ratio < 1)]
 
-    lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(lr_threshold))
-    upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(lr_threshold))
+    # use the most conservative LLR as bound (closest to 0, assuming all are on the expected size of 0)
+    lower_bound = np.max(eu_negative_left + step_size, initial=np.min(llr_threshold))
+    upper_bound = np.min(eu_negative_right - step_size, initial=np.max(llr_threshold))
 
-    # Check for bounds on the wrong side of 1. This may occur for badly
+    # Check for bounds on the wrong side of 0. This may occur for badly
     # performing LR systems, e.g. if expected utility is always below neutral.
-    lower_bound = min(lower_bound, 1)
-    upper_bound = max(upper_bound, 1)
+    lower_bound = min(lower_bound, 0)
+    upper_bound = max(upper_bound, 0)
 
     return lower_bound, upper_bound
 
@@ -153,5 +157,5 @@ class ELUBBounder(LLRBounder):
     """
 
     def calculate_bounds(self, llrs: np.ndarray, labels: np.ndarray) -> tuple[float | None, float | None]:
-        lower_lr_bound, upper_lr_bound = elub(logodds_to_odds(llrs), labels, add_misleading=1)
-        return odds_to_logodds(lower_lr_bound), odds_to_logodds(upper_lr_bound)
+        lower_lr_bound, upper_lr_bound = elub(llrs, labels, add_misleading=1)
+        return lower_lr_bound, upper_lr_bound

--- a/lir/algorithms/bayeserror.py
+++ b/lir/algorithms/bayeserror.py
@@ -66,8 +66,8 @@ def elub(
     sanitized_llrs[sanitized_llrs > substitute_extremes[1]] = substitute_extremes[1]
 
     # determine the range of LLRs to be considered, using dataset sizes: LB > -log10(size(Hp)+1), UB < log10(size(Hd)+1)
-    llr_min = max((np.min(sanitized_llrs), -np.log10(np.sum(y) + 1)))
-    llr_max = min((np.max(sanitized_llrs), np.log10(np.sum(1 - y) + 1)))
+    llr_min = max(np.min(sanitized_llrs), -np.log10(np.sum(y) + 1))
+    llr_max = min(np.max(sanitized_llrs), np.log10(np.sum(1 - y) + 1))
     llr_steps_min = min(0, int(np.floor_divide(llr_min, step_size)))
     llr_steps_max = max(0, int((np.floor_divide(llr_max, step_size)) + 1))
     llr_threshold = np.linspace(llr_steps_min * step_size, llr_steps_max * step_size, llr_steps_max - llr_steps_min + 1)

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -13,54 +13,54 @@ from lir.util import Xn_to_Xy, probability_to_logodds, logodds_to_odds
 class TestElub(unittest.TestCase):
     def test_breath(self):
         data = AlcoholBreathAnalyser(ill_calibrated=True).get_instances()
-        bounds = bayeserror.elub(logodds_to_odds(data.llrs), data.labels, add_misleading=1)
-        np.testing.assert_almost_equal((0.11051160265422605, 80.42823031359497), bounds)
+        bounds = bayeserror.elub(data.llrs, data.labels, add_misleading=1)
+        np.testing.assert_almost_equal((0.1122018, 79.4328235), np.pow(10, bounds))
 
     def test_extreme_smallset(self):
         lrs = np.array([np.inf, 0])
         y = np.array([1, 0])
-        bounds = bayeserror.elub(lrs, y, add_misleading=1)
-        np.testing.assert_almost_equal((1, 1), bounds)
+        bounds = bayeserror.elub(np.log10(lrs), y, add_misleading=1)
+        np.testing.assert_almost_equal((1, 1), np.pow(10, bounds))
 
     def test_extreme(self):
         lrs = np.array([np.inf, np.inf, np.inf, 0, 0, 0])
         y = np.array([1, 1, 1, 0, 0, 0])
-        bounds = bayeserror.elub(lrs, y, add_misleading=1)
-        np.testing.assert_almost_equal((0.3362165, 2.9742741), bounds)
+        bounds = bayeserror.elub(np.log10(lrs), y, add_misleading=1)
+        np.testing.assert_almost_equal((0.3388442, 2.9512092), np.pow(10, bounds))
 
     def test_system01(self):
         lrs = np.array([0.01, 0.1, 1, 10, 100])
-        bounds_bad = bayeserror.elub(lrs, np.array([1, 1, 1, 0, 0]), add_misleading=1)
-        bounds_good1 = bayeserror.elub(lrs, np.array([0, 0, 1, 1, 1]), add_misleading=1)
-        bounds_good2 = bayeserror.elub(lrs, np.array([0, 0, 0, 1, 1]), add_misleading=1)
+        bounds_bad = bayeserror.elub(np.log10(lrs), np.array([1, 1, 1, 0, 0]), add_misleading=1)
+        bounds_good1 = bayeserror.elub(np.log10(lrs), np.array([0, 0, 1, 1, 1]), add_misleading=1)
+        bounds_good2 = bayeserror.elub(np.log10(lrs), np.array([0, 0, 0, 1, 1]), add_misleading=1)
 
-        np.testing.assert_almost_equal((1, 1), bounds_bad)
-        np.testing.assert_almost_equal((0.3771282, 1.4990474), bounds_good1)
-        np.testing.assert_almost_equal((0.6668633, 2.6507161), bounds_good2)
+        np.testing.assert_almost_equal((1, 1), np.pow(10, bounds_bad))
+        np.testing.assert_almost_equal((0.3801894, 1.4791084), np.pow(10, bounds_good1))
+        np.testing.assert_almost_equal((0.6760830, 2.6302680), np.pow(10, bounds_good2))
 
     def test_neutral_smallset(self):
         lrs = np.array([1, 1])
         y = np.array([1, 0])
-        bounds = bayeserror.elub(lrs, y, add_misleading=1)
-        np.testing.assert_almost_equal((1, 1), bounds)
+        bounds = bayeserror.elub(np.log10(lrs), y, add_misleading=1)
+        np.testing.assert_almost_equal((1, 1), np.pow(10, bounds))
 
     def test_bias(self):
         lrs = np.ones(10) * 10
         y = np.concatenate([np.ones(9), np.zeros(1)])
         np.testing.assert_almost_equal(
-            (1, 1), bayeserror.elub(lrs, y, add_misleading=1)
+            (1, 1), np.pow(10, bayeserror.elub(np.log10(lrs), y, add_misleading=1))
         )
 
         lrs = np.concatenate([np.ones(10) * 10, np.ones(1)])
         y = np.concatenate([np.ones(10), np.zeros(1)])
         np.testing.assert_almost_equal(
-            (1, 1.8039884), bayeserror.elub(lrs, y, add_misleading=1)
+            (1, 1.7782794), np.pow(10, bayeserror.elub(np.log10(lrs), y, add_misleading=1))
         )
 
         lrs = np.concatenate([np.ones(10) * 1000, np.ones(1) * 1.1])
         y = np.concatenate([np.ones(10), np.zeros(1)])
         np.testing.assert_almost_equal(
-            (1, 1), bayeserror.elub(lrs, y, add_misleading=1)
+            (1, 1), np.pow(10, bayeserror.elub(np.log10(lrs), y, add_misleading=1))
         )
 
     def test_bounded_calibrated_scorer(self):
@@ -80,7 +80,7 @@ class TestElub(unittest.TestCase):
         )
         pipeline.fit(X, y)
         bounds = bounder.lower_llr_bound, bounder.upper_llr_bound
-        np.testing.assert_almost_equal((-1.5313757, 2.0211532), bounds)
+        np.testing.assert_almost_equal((-1.53, 2.02), bounds)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed to log10-base (for LRs and step size); take into account data set sizes for range of threshold LLRs. Expected test outputs change a bit, due to changing grid.