### PR TITLE
Fix running `lir` CLI commands

### DIFF
--- a/lir/main.py
+++ b/lir/main.py
@@ -58,7 +58,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description='Run all or some of the parts of project')
 
     parser.add_argument(
-        'setup',
+        '--setup',
         metavar='FILENAME',
         help='path to YAML file describing the evaluation setup',
     )


### PR DESCRIPTION
The setup option should be defined with `--setup` instead of `setup`, otherwise this will not run.