### PR TITLE
allow custom pipelines

### DIFF
--- a/examples/common_source_evaluation.yaml
+++ b/examples/common_source_evaluation.yaml
@@ -19,27 +19,29 @@ cross_validation_splits:
 lr_system:
   architecture: score_based
   preprocessing:
-    raw_data:
-      method: csv_writer
-      include_labels: True
+    steps:
+      raw_data:
+        method: csv_writer
+        include_labels: True
   pairing:
     method: instance_pairs
     ratio_limit: 1
   comparing:
-    scoring: abs_diff
-    clf:
-      method: logistic_regression
-      C: 1
-    to_llr: probabilities_to_logodds
-    bounding: elub_bounder
-    _results:
-      method: csv_writer
-      include_input: False
-      include_labels: False
-      include_batch: False
-      include:
-        - clf.csv
-        - to_llr.csv
+    steps:
+      scoring: abs_diff
+      clf:
+        method: logistic_regression
+        C: 1
+      to_llr: probabilities_to_logodds
+      bounding: elub_bounder
+      _results:
+        method: csv_writer
+        include_input: False
+        include_labels: False
+        include_batch: False
+        include:
+          - clf.csv
+          - to_llr.csv
 
 experiments:
   model_selection:
@@ -47,7 +49,7 @@ experiments:
     lr_system: ${lr_system}
     data: ${cross_validation_splits}
     hyperparameters:
-      - path: comparing.clf
+      - path: comparing.steps.clf
         options:
           - option_name: logit
             method: logistic_regression

--- a/examples/glass.yaml
+++ b/examples/glass.yaml
@@ -49,43 +49,45 @@ score_based_lr_system:
   architecture: score_based
 
   preprocessing:
-    raw_data: csv_writer  # generate a CSV file containing raw data, named `raw_data.csv`
-    scaler: standard_scaler  # apply the scikit-learn `StandardScaler` with default arguments
+    steps:
+      raw_data: csv_writer  # generate a CSV file containing raw data, named `raw_data.csv`
+      scaler: standard_scaler  # apply the scikit-learn `StandardScaler` with default arguments
 
-    # Generate a CSV file containing all that we know about the instances.
-    _instances:
-      method: csv_writer
-      include_labels: True  # include the ground-truth labels
-      include_meta: True  # include the metadata of the instances
-      include_input: False  # do not write the current values, since we can include them from `scaler.csv`
-      include:  # include the content of the CSV files that we just generated
-        - raw_data.csv
-        - scaler.csv
+      # Generate a CSV file containing all that we know about the instances.
+      _instances:
+        method: csv_writer
+        include_labels: True  # include the ground-truth labels
+        include_meta: True  # include the metadata of the instances
+        include_input: False  # do not write the current values, since we can include them from `scaler.csv`
+        include:  # include the content of the CSV files that we just generated
+          - raw_data.csv
+          - scaler.csv
 
   pairing:
     method: instance_pairs
     ratio_limit: 1  # limit the number of different-source pairs to the number of same-source pairs
 
   comparing:
-    scoring: abs_diff  # calculate the absolute difference between the two instances for each feature
-    clf: logistic_regression  # use scikit-learn `LogisticRegression` to estimate probabilities
-    to_llr: probabilities_to_logodds  # convert probabilities to their log-odds values
-    calibration:  # calibrate the log-odds to LLRs using KDE
-      method: kde
-      bandwidth: silverman
-    bounding: elub_bounder  # prevent excessive extrapolation by applying an LLR bounder
+    steps:
+      scoring: abs_diff  # calculate the absolute difference between the two instances for each feature
+      clf: logistic_regression  # use scikit-learn `LogisticRegression` to estimate probabilities
+      to_llr: probabilities_to_logodds  # convert probabilities to their log-odds values
+      calibration:  # calibrate the log-odds to LLRs using KDE
+        method: kde
+        bandwidth: silverman
+      bounding: elub_bounder  # prevent excessive extrapolation by applying an LLR bounder
 
-    # Accumulate all intermediate results and write them to a CSV file.
-    _results:
-      method: csv_writer
-      include_labels: True  # include the ground truth labels
-      include_meta: True  # include the metadata on the pairs
-      include_input: False  # skip the input data, since we can read it from CSV
-      include:
-        - clf.csv
-        - to_llr.csv
-        - calibration.csv
-        - bounding.csv
+      # Accumulate all intermediate results and write them to a CSV file.
+      _results:
+        method: csv_writer
+        include_labels: True  # include the ground truth labels
+        include_meta: True  # include the metadata on the pairs
+        include_input: False  # skip the input data, since we can read it from CSV
+        include:
+          - clf.csv
+          - to_llr.csv
+          - calibration.csv
+          - bounding.csv
 
 two_level_lr_system:
   # The `two_level` architecture takes three arguments:
@@ -97,21 +99,23 @@ two_level_lr_system:
   n_trace_instances: 2
   n_ref_instances: 3
   preprocessing:
-    scaler: standard_scaler
+    steps:
+      scaler: standard_scaler
   pairing:
     method: source_pairs
     ratio_limit: 1
   postprocessing:
-    llr: csv_writer
-    bound_llr: elub_bounder
-    _results:
-      method: csv_writer
-      include_labels: True
-      include_meta: True
-      include_input: False
-      include:
-        - llr.csv
-        - bound_llr.csv
+    steps:
+      llr: csv_writer
+      bound_llr: elub_bounder
+      _results:
+        method: csv_writer
+        include_labels: True
+        include_meta: True
+        include_input: False
+        include:
+          - llr.csv
+          - bound_llr.csv
   seed: 42
 
 # Below we define how the LR system should be evaluated. We define three experiments:
@@ -135,13 +139,13 @@ experiments:
   # values are substituted in the base configuration of the LR system. Where exactly the values are substituted is
   # defined by the *path* in the base configuration.
   #
-  # For example, the path to the `standard_scaler` in the `score_based_lr_system` is "preprocessing.scaler". The scaler
+  # For example, the path to the `standard_scaler` in the `score_based_lr_system` is "preprocessing.steps.scaler". The scaler
   # can be defined as a categorical hyperparameter as follows.
   #
   # ```
   # hyperparameters:
   #   - name: scaling method  # optional, defaults to `path`
-  #     path: preprocessing.scaler
+  #     path: preprocessing.steps.scaler
   #     options:
   #       - standard_scaler
   #       - min_max_scaler
@@ -157,19 +161,19 @@ experiments:
   #     options:
   #       - option_name: svm_and_kde
   #         substitutions:
-  #           - path: comparing.clf
+  #           - path: comparing.steps.clf
   #             value:
   #               method: svm
   #               probability: True
-  #           - path: comparing.calibration
+  #           - path: comparing.steps.calibration
   #             value:
   #               method: kde
   #               bandwidth: silverman
   #       - option_name: logit
   #         substitutions:
-  #           - path: comparing.clf
+  #           - path: comparing.steps.clf
   #             value: logistic_regression
-  #           - path: comparing.calibration
+  #           - path: comparing.steps.calibration
   #             value: csv_writer
   # ```
   #
@@ -178,7 +182,7 @@ experiments:
   # ```
   # hyperparameters:
   #   - name: kde_bandwidth
-  #     path: comparing.calibration.bandwidth
+  #     path: comparing.steps.calibration.bandwidth
   #     low: .1
   #     high: 1
   #     log: False
@@ -197,19 +201,19 @@ experiments:
         options:
           - option_name: svm_and_kde
             substitutions:
-              - path: comparing.clf
+              - path: comparing.steps.clf
                 value:
                   method: svm
                   probability: True
-              - path: comparing.calibration
+              - path: comparing.steps.calibration
                 value:
                   method: kde
                   bandwidth: silverman
           - option_name: logit
             substitutions:
-              - path: comparing.clf
+              - path: comparing.steps.clf
                 value: logistic_regression
-              - path: comparing.calibration
+              - path: comparing.steps.calibration
                 value: csv_writer
 
     metrics:

--- a/examples/specific_source_evaluation.yaml
+++ b/examples/specific_source_evaluation.yaml
@@ -21,23 +21,24 @@ cross_validation_splits:
 lr_system:
   architecture: specific_source
   modules:
-    raw_data:
-      method: csv_writer
-      include_labels: True
-    scaler: standard_scaler
-    clf:
-      method: logistic_regression
-      C: 1
-    to_llr: probabilities_to_logodds
-    _results:
-      method: csv_writer
-      include_input: False
-      include_batch: False
-      include:
-        - raw_data.csv
-        - scaler.csv
-        - clf.csv
-        - to_llr.csv
+    steps:
+      raw_data:
+        method: csv_writer
+        include_labels: True
+      scaler: standard_scaler
+      clf:
+        method: logistic_regression
+        C: 1
+      to_llr: probabilities_to_logodds
+      _results:
+        method: csv_writer
+        include_input: False
+        include_batch: False
+        include:
+          - raw_data.csv
+          - scaler.csv
+          - clf.csv
+          - to_llr.csv
 
 experiments:
   model_selection:
@@ -45,7 +46,7 @@ experiments:
     lr_system: ${lr_system}
     data: ${cross_validation_splits}
     hyperparameters:
-      - path: modules.clf
+      - path: modules.steps.clf
         options:
           - option_name: logit
             method: logistic_regression

--- a/lir/__init__.py
+++ b/lir/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+from lir.transform import Transformer as Transformer  # as required by linting, later to be replaced by __all__
+
 
 def is_interactive() -> bool:
     return logging.getLogger(__name__).level >= logging.WARNING and sys.stdout.isatty()

--- a/lir/algorithms/bootstraps.py
+++ b/lir/algorithms/bootstraps.py
@@ -5,10 +5,9 @@ from typing import Any, Self
 import numpy as np
 from scipy.interpolate import interp1d
 
-from lir.config.base import ContextAwareDict, config_parser, pop_field
-from lir.config.lrsystem_architectures import parse_pipeline
+from lir.config.base import ContextAwareDict, check_not_none, config_parser, pop_field
 from lir.data.models import FeatureData, LLRData
-from lir.transform.pipeline import Pipeline
+from lir.transform.pipeline import Pipeline, parse_steps
 
 
 class Bootstrap(Pipeline, ABC):
@@ -218,5 +217,5 @@ def bootstrap(modules_config: ContextAwareDict, output_dir: Path) -> BootstrapAt
     }
 
     bootstrap_method = pop_field(modules_config, 'points', validate=bootstrap_methods.get)
-    pipeline = parse_pipeline(pop_field(modules_config, 'steps'), output_dir)
-    return bootstrap_method(pipeline.steps, **modules_config)
+    steps = parse_steps(pop_field(modules_config, 'steps', validate=check_not_none), output_dir)
+    return bootstrap_method(steps, **modules_config)

--- a/lir/config/base.py
+++ b/lir/config/base.py
@@ -173,6 +173,12 @@ def parse_pairing_config(
     )
 
 
+def check_not_none(v: Any) -> Any:
+    if v is None:
+        raise ValueError('value None is not allowed here')
+    return v
+
+
 def pop_field(
     config: ContextAwareDict | Any,
     field: str,

--- a/lir/lrsystems/binary_lrsystem.py
+++ b/lir/lrsystems/binary_lrsystem.py
@@ -1,5 +1,5 @@
+from lir import Transformer
 from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
-from lir.transform.pipeline import Pipeline
 
 
 class BinaryLRSystem(LRSystem):
@@ -13,7 +13,7 @@ class BinaryLRSystem(LRSystem):
     afterward calculate corresponding LLR's for given feature vectors.
     """
 
-    def __init__(self, name: str, pipeline: Pipeline):
+    def __init__(self, name: str, pipeline: Transformer):
         super().__init__(name)
         self.pipeline = pipeline
 

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,3 +1,4 @@
+from lir import Transformer
 from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
 from lir.transform.pairing import PairingMethod
 from lir.transform.pipeline import Pipeline
@@ -15,9 +16,9 @@ class ScoreBasedSystem(LRSystem):
     def __init__(
         self,
         name: str,
-        preprocessing_pipeline: Pipeline | None,
+        preprocessing_pipeline: Transformer | None,
         pairing_function: PairingMethod,
-        evaluation_pipeline: Pipeline | None,
+        evaluation_pipeline: Transformer | None,
     ):
         super().__init__(name)
         self.preprocessing_pipeline = preprocessing_pipeline or Pipeline([])

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from scipy.special import logsumexp
 
+from lir import Transformer
 from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
 from lir.transform.pairing import PairingMethod
 from lir.transform.pipeline import Pipeline
@@ -413,9 +414,9 @@ class TwoLevelSystem(LRSystem):
     def __init__(
         self,
         name: str,
-        preprocessing_pipeline: Pipeline | None,
+        preprocessing_pipeline: Transformer | None,
         pairing_function: PairingMethod,
-        postprocessing_pipeline: Pipeline | None,
+        postprocessing_pipeline: Transformer | None,
         n_trace_instances: int,
         n_ref_instances: int,
     ):

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -16,6 +16,10 @@ data_providers:
   synthesized_normal_multiclass: lir.data.datasets.synthesized_normal_multiclass.synthesized_normal_multiclass
   glass: lir.data.datasets.glass.GlassData
 modules:
+  # pipelines
+  pipeline: lir.transform.pipeline.pipeline
+  bootstrap: lir.algorithms.bootstraps.bootstrap
+
   # transformations
   standard_scaler:
     class: sklearn.preprocessing.StandardScaler

--- a/tests/resources/setup.yaml
+++ b/tests/resources/setup.yaml
@@ -20,8 +20,9 @@ data_splits:
 lr_system:
   architecture: specific_source
   modules:
-    clf: logistic_regression
-    to_llr: probabilities_to_logodds
+    steps:
+      clf: logistic_regression
+      to_llr: probabilities_to_logodds
 
 experiments:
   exp1:
@@ -29,7 +30,7 @@ experiments:
     lr_system: ${lr_system}
     data: ${data_splits}
     hyperparameters:
-      - path: modules.clf
+      - path: modules.steps.clf
         options:
           - option_name: logit
             method: logistic_regression

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -93,13 +93,13 @@ def test_traindata_bootstrap_empty_pipeline():
 @pytest.mark.parametrize("config", [
     (
             {
-                "steps": None,
+                "steps": {},
                 "points": "data",
             }
     ),
     (
             {
-                "steps": None,
+                "steps": {},
                 "points": "equidistant",
                 "n_points": 1000,
             }


### PR DESCRIPTION
- allow custom pipelines, as a step towards simplifying the debugging csv writing process (issue #47)
- a pipeline can be replaced by any transformer by using the `method` keyword
- this adds one level to lrsystem YAML configurations (this BREAKS existing YAMLs)
- with this change, boostrapping pipelines can also be integrated