### PR TITLE
LLR Interval plot and `ndarray` to `LLRData`

### DIFF
--- a/lir/experiment.py
+++ b/lir/experiment.py
@@ -65,7 +65,7 @@ class Experiment(ABC):
         output_dir = self.output_path / lrsystem.name
         LOG.debug(f'writing visualizations to {output_dir}')
         for visualization_function in self.visualization_functions:
-            visualization_function(output_dir, llrs, labels)
+            visualization_function(output_dir, combined_llrs, labels)
 
         # Construct a `results` dictionary of metrics indicating the performance of the given LR system
         for aggregation in self.aggregations:

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -319,8 +319,8 @@ def llr_interval(llrdata: LLRData, ax: Axes = plt) -> None:
     interval_scores_low = llr_sorted[:, 1] - llrs
     interval_scores_high = llr_sorted[:, 2] - llrs
 
-    ax.plot(llrs, interval_scores_high, '|-', linewidth=0.5, color='red', label='Upper interval')
-    ax.plot(llrs, interval_scores_low, '|-', linewidth=0.5, color='blue', label='Lower interval')
+    ax.plot(llrs, interval_scores_high, '|-', linewidth=0.5, color=H1_COLOR, label='Upper interval')
+    ax.plot(llrs, interval_scores_low, '|-', linewidth=0.5, color=H2_COLOR, label='Lower interval')
 
     ax.axhline(y=0, color='gray', linestyle='--')
 

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -258,10 +258,11 @@ def lr_histogram(
     bins = np.histogram_bin_edges(llrs, bins=bins)
     points0, points1 = util.Xy_to_Xn(llrs, y)
     weights0, weights1 = (np.ones_like(points) / len(points) if weighted else None for points in (points0, points1))
-    ax.hist(points1, bins=bins, alpha=0.25, weights=weights1)
-    ax.hist(points0, bins=bins, alpha=0.25, weights=weights0)
+    ax.hist(points1, bins=bins, alpha=0.25, weights=weights1, label=f'H1 (n={len(points1)})', color=H1_COLOR)
+    ax.hist(points0, bins=bins, alpha=0.25, weights=weights0, label=f'H2 (n={len(points0)})', color=H2_COLOR)
     ax.set_xlabel('log$_{10}$(LR)')
     ax.set_ylabel('count' if not weighted else 'relative frequency')
+    ax.legend()
 
 
 def tippett(llrs: np.ndarray, y: np.ndarray, plot_type: int = 1, ax: Axes = plt) -> None:

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -318,8 +318,8 @@ def llr_interval(llrdata: LLRData, ax: Axes = plt) -> None:
     interval_scores_low = llr_sorted[:, 1] - llrs
     interval_scores_high = llr_sorted[:, 2] - llrs
 
-    ax.plot(llrs, interval_scores_low, '|-', linewidth=0.5, color='blue', label='Lower interval')
     ax.plot(llrs, interval_scores_high, '|-', linewidth=0.5, color='red', label='Upper interval')
+    ax.plot(llrs, interval_scores_low, '|-', linewidth=0.5, color='blue', label='Lower interval')
 
     ax.axhline(y=0, color='gray', linestyle='--')
 

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -64,6 +64,7 @@ visualization:
   pav: lir.visualization.pav
   ece: lir.visualization.ece
   lr_histogram: lir.visualization.lr_histogram
+  llr_interval: lir.visualization.llr_interval
 pairing:
   instance_pairs: lir.transform.pairing.InstancePairing
   source_pairs: lir.transform.pairing.SourcePairing

--- a/lir/visualization.py
+++ b/lir/visualization.py
@@ -2,28 +2,37 @@ from pathlib import Path
 
 import numpy as np
 
+from lir.data.models import LLRData
 from lir.plotting import savefig
 
 
-def pav(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def pav(base_path: Path, llrs: LLRData, labels: np.ndarray) -> None:
     """Helper function to generate and save a PAV-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / 'pav.png'
     with savefig(str(path)) as fig:
-        fig.pav(llrs, labels)
+        fig.pav(llrs.llrs, labels)
 
 
-def ece(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def ece(base_path: Path, llrs: LLRData, labels: np.ndarray) -> None:
     """Helper function to generate and save an ECE-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / 'ece.png'
     with savefig(str(path)) as fig:
-        fig.ece(llrs, labels)
+        fig.ece(llrs.llrs, labels)
 
 
-def lr_histogram(base_path: Path, llrs: np.ndarray, labels: np.ndarray) -> None:
+def lr_histogram(base_path: Path, llrs: LLRData, labels: np.ndarray) -> None:
     """Helper function to generate and save an histogram-plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / 'histogram.png'
     with savefig(str(path)) as fig:
-        fig.lr_histogram(llrs, labels)
+        fig.lr_histogram(llrs.llrs, labels)
+
+
+def llr_interval(base_path: Path, llrs: LLRData, labels: np.ndarray = None) -> None:
+    """Helper function to generate and save a Score-LR plot to the output directory."""
+    base_path.mkdir(exist_ok=True, parents=True)
+    path = base_path / 'llr_interval.png'
+    with savefig(str(path)) as fig:
+        fig.llr_interval(llrs)

--- a/lir/visualization.py
+++ b/lir/visualization.py
@@ -30,7 +30,7 @@ def lr_histogram(base_path: Path, llrs: LLRData, labels: np.ndarray) -> None:
         fig.lr_histogram(llrs.llrs, labels)
 
 
-def llr_interval(base_path: Path, llrs: LLRData, labels: np.ndarray = None) -> None:
+def llr_interval(base_path: Path, llrs: LLRData, labels: np.ndarray | None = None) -> None:
     """Helper function to generate and save a Score-LR plot to the output directory."""
     base_path.mkdir(exist_ok=True, parents=True)
     path = base_path / 'llr_interval.png'

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -9,6 +9,7 @@ import pytest
 
 from lir import plotting
 from lir.algorithms.logistic_regression import LogitCalibrator
+from lir.data.models import LLRData
 from lir.util import odds_to_probability, odds_to_logodds
 
 
@@ -41,6 +42,7 @@ class TestPlotting(unittest.TestCase):
         scores = odds_to_probability(lrs)
         y = np.array([0, 0, 1, 0, 1, 0, 1, 1, 1, 0])
         finite_index = (lrs > 0) & (lrs < np.inf)
+        llr_data = LLRData(features=np.ones((10, 3)))
 
         with plotting.axes() as ax:
             ax.pav(llrs, y)
@@ -63,6 +65,9 @@ class TestPlotting(unittest.TestCase):
 
         with plotting.axes() as ax:
             ax.score_distribution(scores, y)
+
+        with plotting.axes() as ax:
+            ax.llr_interval(llr_data)
 
         cal = LogitCalibrator()
         cal.fit(scores, y)


### PR DESCRIPTION
This PR:
- Changes `ndarray` to `LLRData` when calling visualizations methods (like those in `lir/visualization.py`)
- Create LLR interval plot, which looks like this (for now):

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/a89af6eb-c587-4f0d-a194-c6b3bcd31b31" />

