### PR TITLE
Fix error in shape in KDE

### DIFF
--- a/examples/bootstrap.yaml
+++ b/examples/bootstrap.yaml
@@ -1,0 +1,51 @@
+output: output/${timestamp}_bootstrap
+
+data:
+  provider: synthesized_normal_binary
+  seed: 42
+  h1:
+    mean: 1
+    std: 1
+    size: 1000
+  h2:
+    mean: -1
+    std: 1
+    size: 1000
+
+cross_validation_splits:
+  strategy: binary_cross_validation
+  folds: 5
+  seed: 42
+  source: ${data}
+
+lr_system:
+  architecture: specific_source
+  modules:
+    steps:
+      bootstrap:
+        method: bootstrap
+        n_bootstraps: 2
+        seed: 0
+        points: data
+        # n_points: 100
+        steps:
+          kde:
+            method: kde
+            bandwidth:
+              - 0.05  
+              - 0.23 
+          elub: elub_bounder
+          
+experiments:
+  model_selection:
+    strategy: single_run
+    lr_system: ${lr_system}
+    data: ${cross_validation_splits}
+    aggregation:
+      metrics:
+        - cllr
+        - cllr_min
+    visualization:
+      - pav
+      - ece
+      - llr_interval

--- a/examples/bootstrap.yaml
+++ b/examples/bootstrap.yaml
@@ -21,21 +21,19 @@ cross_validation_splits:
 lr_system:
   architecture: specific_source
   modules:
+    method: bootstrap
+    n_bootstraps: 2
+    seed: 0
+    points: data
+    # n_points: 100
     steps:
-      bootstrap:
-        method: bootstrap
-        n_bootstraps: 2
-        seed: 0
-        points: data
-        # n_points: 100
-        steps:
-          kde:
-            method: kde
-            bandwidth:
-              - 0.05  
-              - 0.23 
-          elub: elub_bounder
-          
+      kde:
+        method: kde
+        bandwidth:
+          - 0.05  
+          - 0.23 
+      elub: elub_bounder
+        
 experiments:
   model_selection:
     strategy: single_run

--- a/lir/algorithms/kde.py
+++ b/lir/algorithms/kde.py
@@ -145,7 +145,7 @@ class KDECalibrator(BaseEstimator, TransformerMixin):
         log10_compensator = np.log10(self.numerator / self.denominator)
         LLRs_output[el] = log10_compensator + log10_dif
 
-        return LLRs_output
+        return LLRs_output.flatten()
 
     @staticmethod
     def _parse_bandwidth(


### PR DESCRIPTION
The shape of an list of LLR's should have 1 dimension `(n,)`. However, the KDE returns a `(n,1)` object. By flattening the 
returned object in KDE, we resolve this issue. 

This error came to light by using the bootstrap pipeline. Thus, this PR also contains improvements for the tests of the bootstraps. In particular, a example `.yaml` using bootstrap is given, and the bootstrap tests are extended by using ELUB.

