### PR TITLE
Enable bounds for multiple LR-systems at once

### DIFF
--- a/tests/test_bounding.py
+++ b/tests/test_bounding.py
@@ -111,7 +111,7 @@ def test_static_bounder(
         (  # invalid dimensions for llrs
             -1,
             1,
-            np.zeros((3, 1)),
+            np.zeros((3, 1, 2)),
             np.array([0, 1, 1]),
         ),
         (  # invalid dimensions for labels


### PR DESCRIPTION
Add support for multiple LR-systems during bounding, required for LR-systems based on MCMC-simulations.