### PR TITLE
Add Project Documentation (github pages) + Contributor Guidelines

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,26 @@
+name: Generate documentation
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-${{ github.ref }}
+          path: .cache
+          restore-keys: |
+            mkdocs-
+      - run: pip install mkdocs
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 /.pdm-python
 /.python-version
 .testmondata
+
+# MKdocs
+/docs_html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing Guide
+
+Thank you for your interest in contributing to this project! This guide outlines the process for reporting issues, proposing features, and submitting pull requests.
+
+## 1. Ways to Contribute
+
+You can contribute in several ways:
+
+- Reporting bugs
+- Requesting new features
+- Improving documentation
+- Submitting code via pull requests
+- Testing or reviewing existing PRs
+
+## 2. Issues
+
+- Check existing issues before opening a new one
+- Use clear titles and detailed descriptions
+- Include steps to reproduce bugs whenever possible
+- If applicable, please add appropriate labels (e.g., `bug`, `enhancement`, `documentation`)
+  - There are multiple project specific labels as well, e.g. `module:plotting`
+
+## 3. Working on New Features
+
+- Discuss large changes in an issue before starting development
+- Create a dedicated branch, e.g., `feature/your-feature-name`
+- Keep your code consistent with the project’s style and structure
+
+## 4. Pull Requests
+
+- Make sure your fork/branch is up to date with the `main` branch
+- Provide a clear explanation of what the PR does and why
+- Add tests if the project includes test coverage
+- Ensure all existing tests pass
+- Keep PRs small and focused to make reviews easier
+
+## 5. Code Style & Conventions
+
+- Follow the project’s established coding standards as configured in `pyproject.toml`
+  - This project recommends using `pdm` as the preferred package manager, which provides access to `pdm run all`, performing the checks automatically.
+- Use clear and descriptive commit messages
+- Add comments or documentation where necessary
+
+## 6. Documentation
+
+- Update documentation when adding or modifying functionality
+- Modify the README, wiki, or inline documentation as needed
+
+## 7. Releases
+
+- Releases are handled by the maintainers
+- All releases follow semantic versioning: `major.minor.patch`
+
+## 8. Contact
+
+- If you have any questions or suggestions, please open an issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,10 @@ You can contribute in several ways:
 - Improving documentation
 - Submitting code via pull requests
 - Testing or reviewing existing PRs
+- Donate a forensic dataset or link an existing dataset
+- Share your story of using this package
+- Cite this package in publications or presentations
+
 
 ### 1. Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,74 @@
 # Contributing Guide
 
-Thank you for your interest in contributing to this project! This guide outlines the process for reporting issues, proposing features, and submitting pull requests.
+Thank you for your interest in contributing to this project!
 
-## 1. Ways to Contribute
+This guide outlines the process for setting up the project, reporting issues, proposing features, and submitting pull requests.
+
+## Table of Contents
+
+1. [Setting up the project locally](#setting-up-the-project-locally)
+2. [Ways to contribute](#ways-to-contribute)
+
+
+## Setting up the project locally
+
+When cloning and setting up the project for the first time, please follow these steps (once).
+
+### Source code
+
+Clone the repository as follows:
+
+```shell
+git clone https://github.com/NetherlandsForensicInstitute/lir.git
+```
+
+This project uses [pdm](https://pdm-project.org/en/latest/) as a dependency manager. For installation of PDM, please consult the
+[PDM project website](https://pdm-project.org/en/latest/#installation). It is encouraged to use PDM when contributing to this package.
+
+Having PDM installed, install all dependencies of the project, run the following command to install the project
+dependencies and `dev` dependencies used in local development.
+
+```shell
+pdm sync -G dev
+```
+
+A `.venv` directory will be created and used by PDM by default to run the python code as defined in the PDM run scripts.
+
+This will give you the command to launch LIR with all settings in place:
+
+```shell
+pdm run lir --help
+```
+
+### Adding new dependencies
+New dependencies should be installed through `pdm add <dependency_name>`.
+New develop only, i.e. "dev" dependencies should be added using `pdm add <dev_dependency_name> -G dev`.
+
+When developing locally, the following PDM scripts can be employed:
+- Run linting / formatting / static analysis: `pdm check`
+- Run tests: `pdm test`
+- Run all checks and tests: `pdm all`
+
+Dependencies can be upgraded using `pdm install` which also updates the `pdm.lock` lockfile.
+Please only use `pdm install` if you want/need to update the package constraints and know what you're doing, otherwise
+use `pdm sync` (or `pdm sync -G dev` to include the development dependencies).
+
+### Setting up git pre-commit hook (Optional)
+To run all checks before committing, you can optionally add a git pre-commit hook which ensures all checks and balances are green
+before making a new commit.
+
+Copy the `pre-commit.example` file to the `.git/hooks` folder within this project and rename it to `pre-commit`.
+Next, make sure the `pre-commit` file is executable. You can run the following shell commands in the (PyCharm) terminal
+from the root of the project:
+
+```shell
+cp pre-commit.example .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+---
+
+## Ways to Contribute
 
 You can contribute in several ways:
 
@@ -12,7 +78,7 @@ You can contribute in several ways:
 - Submitting code via pull requests
 - Testing or reviewing existing PRs
 
-## 2. Issues
+### 1. Issues
 
 - Check existing issues before opening a new one
 - Use clear titles and detailed descriptions
@@ -20,13 +86,13 @@ You can contribute in several ways:
 - If applicable, please add appropriate labels (e.g., `bug`, `enhancement`, `documentation`)
   - There are multiple project specific labels as well, e.g. `module:plotting`
 
-## 3. Working on New Features
+### 2. Working on New Features
 
 - Discuss large changes in an issue before starting development
 - Create a dedicated branch, e.g., `feature/your-feature-name`
 - Keep your code consistent with the project’s style and structure
 
-## 4. Pull Requests
+### 3. Pull Requests
 
 - Make sure your fork/branch is up to date with the `main` branch
 - Provide a clear explanation of what the PR does and why
@@ -34,23 +100,33 @@ You can contribute in several ways:
 - Ensure all existing tests pass
 - Keep PRs small and focused to make reviews easier
 
-## 5. Code Style & Conventions
+### 4. Code Style & Conventions
 
 - Follow the project’s established coding standards as configured in `pyproject.toml`
   - This project recommends using `pdm` as the preferred package manager, which provides access to `pdm run all`, performing the checks automatically.
 - Use clear and descriptive commit messages
 - Add comments or documentation where necessary
 
-## 6. Documentation
+### 5. Documentation
 
-- Update documentation when adding or modifying functionality
-- Modify the README, wiki, or inline documentation as needed
+Please update the documentation when adding or modifying functionality. The documentation is build from the markdown files
+in the `docs/` directory using [MkDocs](https://www.mkdocs.org/) and published to GitHub pages. The latest version of
+the documentation resides at https://netherlandsforensicinstitute.github.io/lir/.
 
-## 7. Releases
+For each Pull Request, please include any relevant updates in the `docs/*.md` files (preferably in a separate commit). The
+documentation will be rebuild upon merging the work into the `main` branch, as part of a GitHub workflow.
+
+The documentation can be generated locally (for inspection) in multiple ways:
+ - `pdm run serve` provides a preview webserver to browse through the documentation using a web browser
+ - `pdm run mkdocs build` generates a `docs_html` output directory for manual inspection
+
+Please also modify the README, wiki, or inline documentation as needed.
+
+### 7. Releases
 
 - Releases are handled by the maintainers
 - All releases follow semantic versioning: `major.minor.patch`
 
-## 8. Contact
+### 8. Contact
 
 - If you have any questions or suggestions, please open an issue

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Documentation
 Please consult [the dedicated documentation](https://netherlandsforensicinstitute.github.io/lir/) for a comprehensive overview of LiR, terminology and more on developing LR systems.
 
 
+Practitioner's Guide notebook
+-----------------------------
+
+- There is a dedicated Jupyter Notebook which uses LiR to develop LR systems for the comparison of glass measurements, accompanying the paper ["From data to a validated score-based LR system: A practitioner’s guide" - Leegwater et al.](https://doi.org/10.1016/j.forsciint.2024.111994)
+- The notebook resides on the [practitioner_guide](https://github.com/NetherlandsForensicInstitute/lir/tree/practitioner_guide) branch.
+- The notebook is also available on [Google Colab](https://colab.research.google.com/github/NetherlandsForensicInstitute/lir/blob/practitioner_guide/practitioners_guide_glass.ipynb)
+
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -22,38 +22,6 @@ LIR is compatible with Python 3.11 and later. The easiest way to install LIR is 
 pip install lir
 ```
 
-Terminology
------------
-
-- **lr system**: An algorithm to calculate likelihood ratios.
-- **lr system architecture**: A way to compose an LR system, e.g. feature based, specific source, etc.
-- **source**: Something that can generate instances, or where instances are derived from. This is typically the level
-  relevant to the forensic question and the hypotheses. Examples**: a glass pane, a person whose face may be pictured, a
-  speaker of the voice, a shoe.
-- **instance**: A single manifestation of a source. Traces and reference samples are instances of a source. In a feature
-  based system, instances are used as the building blocks for modeling hypotheses. Examples**: the measurements on a
-  fragment of glass, a face image, a voice recording, a shoe print.
-- **pair**: A combination of two groups of instances. The instance groups may be same source or different source. In a
-  common-source system, pairs are used as the building blocks for modeling hypotheses. A group may contain of only one
-  instance, or it may consist of multiple repeated measurements of the same source that are compared as one unit.
-- **data set**: A set of instances and/or pairs, labeled or unlabeled, that may be used for calculating likelihood ratios.
-- **label**: The ground-truth value for an instance or a pair. The label may be on the level of the hypothesis (e.g. H1,
-  H2), or on the level of the source (e.g. Speaker1, Speaker2). Hypothesis labels may derived from source labels.
-  In case of a labeled data set, the ground truth (i.e. labels) is known. This will typically be the data that is used
-  for development, analysis or validation of an LR system. Unlabeled data has no ground truth. This will typically be
-  the application data, or case data in a forensic setting.
-- **binary data**: A data set with exactly two different labels, for specific source evaluation (e.g. H1, H2).
-- **multiclass data**: A data set with an arbitrary number of labels, for common source evaluation or for reduction to
-  binary data for specific source evaluation.
-- **data strategy**: The way in which the data are assigned to different applications (validation, calibration, etc.) within
-  the lr system. Well known strategies are train/test split, cross-validation, leave-one-out.
-- **data provider**: A method for making a data set available, e.g. by reading from disk.
-- **run**: Calculations for an lr system on a specific data set, as part of an experiment.
-- **experiment**: A series of one or more runs to calculate lrs, to measure system performance, to evaluate the effect of
-  varying system parameters, or to optimize system parameters.
-- **experiment strategy**: A strategy for specifying system parameter values, e.g. single run, grid search, etc.
-
-
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -58,52 +58,8 @@ It is straightforward to simulate data for experimentation. Currently two very s
 normal distributions.
 
 
-Development
+Contributing / Development
 -----------
 
-### Source code
-
-Clone the repository as follows:
-
-```shell
-git clone https://github.com/NetherlandsForensicInstitute/lir.git
-```
-
-This project uses [pdm](https://pdm-project.org/en/latest/) as a dependency manager. For installation of PDM, please consult the
-[PDM project website](https://pdm-project.org/en/latest/#installation).
-
-Having PDM installed, install all dependencies of the project, run the following command to install the project
-dependencies.
-
-```shell
-pdm install
-```
-
-A `.venv` directory will be created and used by PDM by default to run the python code as defined in the PDM run scripts.
-
-This will give you the command to launch LIR with all settings in place:
-
-```shell
-pdm lir --help
-```
-
-### Setting up git pre-commit hook
-To run all checks before committing, you can add a git pre-commit hook which ensures all checks and balances are green
-before making a new commit.
-
-Copy the `pre-commit.example` file to the `.git/hooks` folder within this project and rename it to `pre-commit`. 
-Next, make sure the `pre-commit` file is executable. You can run the following shell commands in the (PyCharm) terminal
-from the root of the project:
-
-```shell
-cp pre-commit.example .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
-
-### Adding new dependencies
-New dependencies should be installed through `pdm add <dependency_name>`.
-
-When developing locally, the following PDM scripts can be employed:
-- Run linting / formatting / static analysis: `pdm check`
-- Run tests: `pdm test`
-- Run all checks and tests: `pdm all`
+Contributions are highly welcomed. If you'd like to contribute to the LiR package, please follow the steps as described
+in the [CONTRIBUTING.md](CONTRIBUTING.md) file.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ and computation of case LRs.
 
 LIR was first released in 2020 and redesigned from scratch in 2025, replacing the [previous repository](https://github.com/NetherlandsForensicInstitute/lir-deprecated).
 
+Documentation
+-------------
+
+Please consult [the dedicated documentation](https://netherlandsforensicinstitute.github.io/lir/) for a comprehensive overview of LiR, terminology and more on developing LR systems.
+
+
 Installation
 ------------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,17 +5,6 @@ Toolkit for developing, optimising and evaluating Likelihood Ratio (LR) systems.
 on different datasets, investigating impact of different sampling schemes or techniques, and doing case-based validation
 and computation of case LRs.
 
-LIR was first released in 2020 and redesigned from scratch in 2025, replacing the [previous repository](https://github.com/NetherlandsForensicInstitute/lir-deprecated).
-
-Installation
-------------
-
-LIR is compatible with Python 3.11 and later. The easiest way to install LIR is to use `pip`:
-
-```shell
-pip install lir
-```
-
 Terminology
 -----------
 
@@ -46,30 +35,6 @@ Terminology
 - **experiment**: A series of one or more runs to calculate lrs, to measure system performance, to evaluate the effect of
   varying system parameters, or to optimize system parameters.
 - **experiment strategy**: A strategy for specifying system parameter values, e.g. single run, grid search, etc.
-
-
-Usage
------
-
-This repository offers both a Python API and a command-line interface.
-
-
-Command-line interface
-----------------------
-
-Evaluate an LR system using the command-line interface as follows:
-
-1. define your data, LR system and experiments in a YAML file;
-2. run `lir <yaml file>`.
-
-The `examples` folder may be a good starting point for setting up an experiment.
-
-The elements of the experiment configuration YAML are looked up in the registry. The following lists all available
-elements in the registry.
-
-```commandline
-lir --list-registry
-```
 
 
 Datasets

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,49 +52,8 @@ normal distributions.
 Development
 -----------
 
-### Source code
+### Installation
+To install LiR, install the latest version from PyPI: `pip install lir` in your virtual environment. For more detailed instructions of the CLI please refer to the project [README.md](https://github.com/NetherlandsForensicInstitute/lir/blob/main/README.md#installation).
 
-Clone the repository as follows:
-
-```shell
-git clone https://github.com/NetherlandsForensicInstitute/lir.git
-```
-
-This project uses [pdm](https://pdm-project.org/en/latest/) as a dependency manager. For installation of PDM, please consult the
-[PDM project website](https://pdm-project.org/en/latest/#installation).
-
-Having PDM installed, install all dependencies of the project, run the following command to install the project
-dependencies.
-
-```shell
-pdm install
-```
-
-A `.venv` directory will be created and used by PDM by default to run the python code as defined in the PDM run scripts.
-
-This will give you the command to launch LIR with all settings in place:
-
-```shell
-pdm lir --help
-```
-
-### Setting up git pre-commit hook
-To run all checks before committing, you can add a git pre-commit hook which ensures all checks and balances are green
-before making a new commit.
-
-Copy the `pre-commit.example` file to the `.git/hooks` folder within this project and rename it to `pre-commit`. 
-Next, make sure the `pre-commit` file is executable. You can run the following shell commands in the (PyCharm) terminal
-from the root of the project:
-
-```shell
-cp pre-commit.example .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
-
-### Adding new dependencies
-New dependencies should be installed through `pdm add <dependency_name>`.
-
-When developing locally, the following PDM scripts can be employed:
-- Run linting / formatting / static analysis: `pdm check`
-- Run tests: `pdm test`
-- Run all checks and tests: `pdm all`
+### Contributing
+If you want to contribute to the LiR project, please follow the [CONTRIBUTING.md](https://github.com/NetherlandsForensicInstitute/lir/blob/main/CONTRIBUTING.md) guidelines, which include the instructions to set up LiR for local development.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,135 @@
+LIR Python Likelihood Ratio Toolkit
+===================================
+
+Toolkit for developing, optimising and evaluating Likelihood Ratio (LR) systems. This allows benchmarking of LR systems
+on different datasets, investigating impact of different sampling schemes or techniques, and doing case-based validation
+and computation of case LRs.
+
+LIR was first released in 2020 and redesigned from scratch in 2025, replacing the [previous repository](https://github.com/NetherlandsForensicInstitute/lir-deprecated).
+
+Installation
+------------
+
+LIR is compatible with Python 3.11 and later. The easiest way to install LIR is to use `pip`:
+
+```shell
+pip install lir
+```
+
+Terminology
+-----------
+
+- **lr system**: An algorithm to calculate likelihood ratios.
+- **lr system architecture**: A way to compose an LR system, e.g. feature based, specific source, etc.
+- **source**: Something that can generate instances, or where instances are derived from. This is typically the level
+  relevant to the forensic question and the hypotheses. Examples**: a glass pane, a person whose face may be pictured, a
+  speaker of the voice, a shoe.
+- **instance**: A single manifestation of a source. Traces and reference samples are instances of a source. In a feature
+  based system, instances are used as the building blocks for modeling hypotheses. Examples**: the measurements on a
+  fragment of glass, a face image, a voice recording, a shoe print.
+- **pair**: A combination of two groups of instances. The instance groups may be same source or different source. In a
+  common-source system, pairs are used as the building blocks for modeling hypotheses. A group may contain of only one
+  instance, or it may consist of multiple repeated measurements of the same source that are compared as one unit.
+- **data set**: A set of instances and/or pairs, labeled or unlabeled, that may be used for calculating likelihood ratios.
+- **label**: The ground-truth value for an instance or a pair. The label may be on the level of the hypothesis (e.g. H1,
+  H2), or on the level of the source (e.g. Speaker1, Speaker2). Hypothesis labels may derived from source labels.
+  In case of a labeled data set, the ground truth (i.e. labels) is known. This will typically be the data that is used
+  for development, analysis or validation of an LR system. Unlabeled data has no ground truth. This will typically be
+  the application data, or case data in a forensic setting.
+- **binary data**: A data set with exactly two different labels, for specific source evaluation (e.g. H1, H2).
+- **multiclass data**: A data set with an arbitrary number of labels, for common source evaluation or for reduction to
+  binary data for specific source evaluation.
+- **data strategy**: The way in which the data are assigned to different applications (validation, calibration, etc.) within
+  the lr system. Well known strategies are train/test split, cross-validation, leave-one-out.
+- **data provider**: A method for making a data set available, e.g. by reading from disk.
+- **run**: Calculations for an lr system on a specific data set, as part of an experiment.
+- **experiment**: A series of one or more runs to calculate lrs, to measure system performance, to evaluate the effect of
+  varying system parameters, or to optimize system parameters.
+- **experiment strategy**: A strategy for specifying system parameter values, e.g. single run, grid search, etc.
+
+
+Usage
+-----
+
+This repository offers both a Python API and a command-line interface.
+
+
+Command-line interface
+----------------------
+
+Evaluate an LR system using the command-line interface as follows:
+
+1. define your data, LR system and experiments in a YAML file;
+2. run `lir <yaml file>`.
+
+The `examples` folder may be a good starting point for setting up an experiment.
+
+The elements of the experiment configuration YAML are looked up in the registry. The following lists all available
+elements in the registry.
+
+```commandline
+lir --list-registry
+```
+
+
+Datasets
+--------
+There are currently a number of datasets implemented for this project:
+
+- glass: LA-ICP-MS measurements of elemental concentration from floatglass. The data will be downloaded automatically from https://github.com/NetherlandsForensicInstitute/elemental_composition_glass when used in the pipeline for the first time.
+
+### Simulations
+It is straightforward to simulate data for experimentation. Currently two very simple simulations
+`synthesized_normal_binary` and `synthesized_normal_multiclass` are available, with sources and measurements drawn from
+normal distributions.
+
+
+Development
+-----------
+
+### Source code
+
+Clone the repository as follows:
+
+```shell
+git clone https://github.com/NetherlandsForensicInstitute/lir.git
+```
+
+This project uses [pdm](https://pdm-project.org/en/latest/) as a dependency manager. For installation of PDM, please consult the
+[PDM project website](https://pdm-project.org/en/latest/#installation).
+
+Having PDM installed, install all dependencies of the project, run the following command to install the project
+dependencies.
+
+```shell
+pdm install
+```
+
+A `.venv` directory will be created and used by PDM by default to run the python code as defined in the PDM run scripts.
+
+This will give you the command to launch LIR with all settings in place:
+
+```shell
+pdm lir --help
+```
+
+### Setting up git pre-commit hook
+To run all checks before committing, you can add a git pre-commit hook which ensures all checks and balances are green
+before making a new commit.
+
+Copy the `pre-commit.example` file to the `.git/hooks` folder within this project and rename it to `pre-commit`. 
+Next, make sure the `pre-commit` file is executable. You can run the following shell commands in the (PyCharm) terminal
+from the root of the project:
+
+```shell
+cp pre-commit.example .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+### Adding new dependencies
+New dependencies should be installed through `pdm add <dependency_name>`.
+
+When developing locally, the following PDM scripts can be employed:
+- Run linting / formatting / static analysis: `pdm check`
+- Run tests: `pdm test`
+- Run all checks and tests: `pdm all`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: LiR Documentation
+repo_url: https://github.com/NetherlandsForensicInstitute/lir
+repo_name: LiR
+edit_uri: edit/main/docs/
+site_dir: docs_html
+theme:
+  name: readthedocs

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:9838cea87112d9237ba806642217a83a0dc5bc816fe08a04ed82a6bf0bec6385"
+content_hash = "sha256:336583a7d4b24ae698a7a35a7141bdbec3f7076905be1add8a1c1f33afd83c85"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -39,6 +39,20 @@ dependencies = [
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+requires_python = ">=3.10"
+summary = "Composable command line interface toolkit"
+groups = ["dev"]
+dependencies = [
+    "colorama; platform_system == \"Windows\"",
+]
+files = [
+    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
+    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
 ]
 
 [[package]]
@@ -310,6 +324,19 @@ files = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+summary = "Copy your docs directly to the gh-pages branch."
+groups = ["dev"]
+dependencies = [
+    "python-dateutil>=2.8.1",
+]
+files = [
+    {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
+    {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 requires_python = ">=3.9"
@@ -372,6 +399,20 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+requires_python = ">=3.7"
+summary = "A very fast and expressive template engine."
+groups = ["dev"]
+dependencies = [
+    "MarkupSafe>=2.0",
+]
+files = [
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [[package]]
@@ -553,11 +594,22 @@ files = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10"
+requires_python = ">=3.10"
+summary = "Python implementation of John Gruber's Markdown."
+groups = ["dev"]
+files = [
+    {file = "markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c"},
+    {file = "markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 requires_python = ">=3.9"
 summary = "Safely add untrusted strings to HTML/XML markup."
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -703,6 +755,61 @@ files = [
     {file = "matplotlib-3.10.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d2a959c640cdeecdd2ec3136e8ea0441da59bcaf58d67e9c590740addba2cb68"},
     {file = "matplotlib-3.10.7-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3886e47f64611046bc1db523a09dd0a0a6bed6081e6f90e13806dd1d1d1b5e91"},
     {file = "matplotlib-3.10.7.tar.gz", hash = "sha256:a06ba7e2a2ef9131c79c49e63dad355d2d878413a0376c1727c8b9335ff731c7"},
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+requires_python = ">=3.6"
+summary = "A deep merge function for 🐍."
+groups = ["dev"]
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+requires_python = ">=3.8"
+summary = "Project documentation with Markdown."
+groups = ["dev"]
+dependencies = [
+    "click>=7.0",
+    "colorama>=0.4; platform_system == \"Windows\"",
+    "ghp-import>=1.0",
+    "importlib-metadata>=4.4; python_version < \"3.10\"",
+    "jinja2>=2.11.1",
+    "markdown>=3.3.6",
+    "markupsafe>=2.0.1",
+    "mergedeep>=1.3.4",
+    "mkdocs-get-deps>=0.2.0",
+    "packaging>=20.5",
+    "pathspec>=0.11.1",
+    "pyyaml-env-tag>=0.1",
+    "pyyaml>=5.1",
+    "watchdog>=2.0",
+]
+files = [
+    {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
+    {file = "mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2"},
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+requires_python = ">=3.8"
+summary = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
+groups = ["dev"]
+dependencies = [
+    "importlib-metadata>=4.3; python_version < \"3.10\"",
+    "mergedeep>=1.3.4",
+    "platformdirs>=2.2.0",
+    "pyyaml>=5.1",
+]
+files = [
+    {file = "mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"},
+    {file = "mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c"},
 ]
 
 [[package]]
@@ -1041,6 +1148,17 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.5.1"
+requires_python = ">=3.10"
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+groups = ["dev"]
+files = [
+    {file = "platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"},
+    {file = "platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda"},
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 requires_python = ">=3.9"
@@ -1221,7 +1339,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "six>=1.5",
 ]
@@ -1245,7 +1363,7 @@ name = "pyyaml"
 version = "6.0.3"
 requires_python = ">=3.8"
 summary = "YAML parser and emitter for Python"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
@@ -1304,6 +1422,20 @@ files = [
     {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
     {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+requires_python = ">=3.9"
+summary = "A custom YAML tag for referencing environment variables in YAML files."
+groups = ["dev"]
+dependencies = [
+    "pyyaml",
+]
+files = [
+    {file = "pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04"},
+    {file = "pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff"},
 ]
 
 [[package]]
@@ -1453,7 +1585,7 @@ name = "six"
 version = "1.17.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -1577,4 +1709,33 @@ groups = ["default"]
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+requires_python = ">=3.9"
+summary = "Filesystem events monitoring"
+groups = ["dev"]
+files = [
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
+    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
+    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
+    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
+    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest-testmon>=2.1.3",
     "mypy>=1.18.2",
     "ruff>=0.14.3",
+    "mkdocs>=1.6.1",
 ]
 
 [tool.pdm]


### PR DESCRIPTION
This patch includes the following:
 - Add "Ways to contribute" in `CONTRIBUTING.md`
 - Move installation instructions from `README.md` to `CONTRIBUTING.md`
 - Add MkDocs to build the project documentation (for the theoretical part / more comprehensive overview)
 - Add github workflow to publish new documentation when merging into `main`
 - Update Documentation section in `CONTRIBUTING.md` to mention building the MkDocs documentation

The docs can be viewed on GitHub pages: https://netherlandsforensicinstitute.github.io/lir/.
The generated HTML is provisioned to the branch `gh-pages`.

Note: it is best to review this work commit-by-commit.