### PR TITLE
Add upper/lower bounds metrics + Change metrics to use LLRData

### DIFF
--- a/examples/glass.yaml
+++ b/examples/glass.yaml
@@ -223,6 +223,7 @@ experiments:
         - cllr
         - cllr_min
         - cllr_cal
+        - llr_bounds
       - pav
       - lr_histogram
 

--- a/examples/glass.yaml
+++ b/examples/glass.yaml
@@ -223,7 +223,8 @@ experiments:
         - cllr
         - cllr_min
         - cllr_cal
-        - llr_bounds
+        - llr_upper_bound
+        - llr_lower_bound
       - pav
       - lr_histogram
 

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -114,7 +114,6 @@ class WriteMetricsToCsv(Aggregation):
         self.columns = columns
 
     def report(self, data: AggregationData) -> None:
-
         columns = [(key, metric(data.llrdata)) for key, metric in self.columns.items()]
         metrics = []
         for name, value in columns:

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -114,7 +114,7 @@ class WriteMetricsToCsv(Aggregation):
         self.columns = columns
 
     def report(self, data: AggregationData) -> None:
-        columns = [(key, metric(data.llrdata.llrs, data.llrdata.labels)) for key, metric in self.columns.items()]
+        columns = [(key, metric(data.llrdata)) for key, metric in self.columns.items()]
         results = OrderedDict(list(data.parameters.items()) + columns)
 
         # Record column header names only once to the CSV

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -114,8 +114,17 @@ class WriteMetricsToCsv(Aggregation):
         self.columns = columns
 
     def report(self, data: AggregationData) -> None:
+
         columns = [(key, metric(data.llrdata)) for key, metric in self.columns.items()]
-        results = OrderedDict(list(data.parameters.items()) + columns)
+        metrics = []
+        for name, value in columns:
+            if isinstance(value, (list, tuple)):
+                for index, metric_value in enumerate(value):
+                    metrics.append((f'{name}_{index}', str(metric_value)))
+            else:
+                metrics.append((name, str(value)))
+
+        results = OrderedDict(list(data.parameters.items()) + metrics)
 
         # Record column header names only once to the CSV
         if self._writer is None:

--- a/lir/bounding.py
+++ b/lir/bounding.py
@@ -81,7 +81,10 @@ class LLRBounder(Transformer, ABC):
             llrs = np.where(self.lower_llr_bound < llrs, llrs, self.lower_llr_bound)
         if self.upper_llr_bound is not None:
             llrs = np.where(self.upper_llr_bound > llrs, llrs, self.upper_llr_bound)
-        return instances.replace(features=llrs)
+
+        return instances.replace(
+            features=llrs, llr_upper_bound=self.upper_llr_bound, llr_lower_bound=self.lower_llr_bound
+        )
 
 
 class StaticBounder(LLRBounder):

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -342,7 +342,18 @@ class PairedFeatureData(FeatureData):
 class LLRData(FeatureData):
     """
     Representation of calculated LLR values.
+
+    Attributes:
+    - llrs: 1-dimensional numpy array of LLR values
+    - has_intervals: indicate whether the LLR's have intervals
+    - llr_intervals: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals
+    - llr_upper_bound: upper bound applied to the LLRs, or `None` if no upper bound was applied
+    - llr_lower_bound: lower bound applied to the LLRs, or `None` if no lower bound was applied
+
     """
+
+    llr_upper_bound: float | None = None
+    llr_lower_bound: float | None = None
 
     @property
     def llrs(self) -> np.ndarray:
@@ -370,6 +381,16 @@ class LLRData(FeatureData):
             return self.features[:, 1:]
         else:
             return None
+
+    @property
+    def llr_bounds(self) -> tuple[float, float]:
+        """
+        :return: a tuple (min_llr, max_llr)
+        """
+        return (
+            self.llr_lower_bound if self.llr_lower_bound is not None else np.min(self.llrs),
+            self.llr_upper_bound if self.llr_upper_bound is not None else np.max(self.llrs),
+        )
 
     @model_validator(mode='after')
     def check_features_are_llrs(self) -> Self:

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -383,14 +383,11 @@ class LLRData(FeatureData):
             return None
 
     @property
-    def llr_bounds(self) -> tuple[float, float]:
+    def llr_bounds(self) -> tuple[float | None, float | None]:
         """
         :return: a tuple (min_llr, max_llr)
         """
-        return (
-            self.llr_lower_bound if self.llr_lower_bound is not None else np.min(self.llrs),
-            self.llr_upper_bound if self.llr_upper_bound is not None else np.max(self.llrs),
-        )
+        return (self.llr_lower_bound, self.llr_upper_bound)
 
     @model_validator(mode='after')
     def check_features_are_llrs(self) -> Self:

--- a/lir/metrics/__init__.py
+++ b/lir/metrics/__init__.py
@@ -68,16 +68,6 @@ def cllr_cal(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
     return cllr_val - cllr_min_val
 
 
-def llr_bounds(llrs: LLRData) -> tuple[float | None, float | None]:
-    """
-    When an LLRData object contains bounds, return them. If not, return None.
-
-    :param llrs: a numpy array of LLRs
-    :return: a tuple (min_llr, max_llr)
-    """
-    return llrs.llr_bounds
-
-
 def llr_upper_bound(llrs: LLRData) -> float | None:
     """
     When an LLRData object contains an upper bound, return it. If not, return None.
@@ -90,9 +80,9 @@ def llr_upper_bound(llrs: LLRData) -> float | None:
 
 def llr_lower_bound(llrs: LLRData) -> float | None:
     """
-        When an LLRData object contains a lower bound, return it. If not, return None.
-    s
-        :param llrs: a numpy array of LLRs
-        :return: min_llr
+    When an LLRData object contains a lower bound, return it. If not, return None.
+
+    :param llrs: a numpy array of LLRs
+    :return: min_llr
     """
     return llrs.llr_lower_bound

--- a/lir/metrics/__init__.py
+++ b/lir/metrics/__init__.py
@@ -69,3 +69,14 @@ def cllr_cal(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
     cllr_min_val = cllr_min(LLRData(features=llrs, labels=y), weights)
     cllr_val = cllr(LLRData(features=llrs, labels=y), weights)
     return cllr_val - cllr_min_val
+
+
+def llr_bounds(llrs: LLRData) -> tuple[float, float]:
+    """
+    Calculates the minimum and maximum log likelihood ratios from a collection of
+    log likelihood ratios.
+
+    :param llrs: a numpy array of LLRs
+    :return: a tuple (min_llr, max_llr)
+    """
+    return llrs.llr_bounds

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -72,6 +72,7 @@ metric:
   cllr: lir.metrics.cllr
   cllr_min: lir.metrics.cllr_min
   cllr_cal: lir.metrics.cllr_cal
+  llr_bounds: lir.metrics.llr_bounds
 output:
   metrics: lir.aggregation.metrics_csv
   pav: lir.aggregation.plot_pav

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -72,6 +72,8 @@ metric:
   cllr: lir.metrics.cllr
   cllr_min: lir.metrics.cllr_min
   cllr_cal: lir.metrics.cllr_cal
+  llr_lower_bound: lir.metrics.llr_lower_bound
+  llr_upper_bound: lir.metrics.llr_upper_bound
   llr_bounds: lir.metrics.llr_bounds
 output:
   metrics: lir.aggregation.metrics_csv

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -74,7 +74,6 @@ metric:
   cllr_cal: lir.metrics.cllr_cal
   llr_lower_bound: lir.metrics.llr_lower_bound
   llr_upper_bound: lir.metrics.llr_upper_bound
-  llr_bounds: lir.metrics.llr_bounds
 output:
   metrics: lir.aggregation.metrics_csv
   pav: lir.aggregation.plot_pav

--- a/tests/lrsystems/test_two_level.py
+++ b/tests/lrsystems/test_two_level.py
@@ -3,8 +3,8 @@ import pytest
 from lir import metrics
 from lir.data.data_strategies import MulticlassCrossValidation
 from lir.data.datasets.synthesized_normal_multiclass import (
-    SynthesizedNormalMulticlassData,
     SynthesizedDimension,
+    SynthesizedNormalMulticlassData,
 )
 from lir.lrsystems.lrsystems import LLRData
 from lir.lrsystems.two_level import TwoLevelSystem
@@ -15,10 +15,10 @@ def _calculate_cllr(
     mean: float = 0.0, std: float = 1.0, error_std: float = 1.0
 ) -> float:
     params = {
-        "population_size": 20,
-        "sources_size": 6,
-        "dimensions": [SynthesizedDimension(mean, std, error_std)],
-        "seed": 0,
+        'population_size': 20,
+        'sources_size': 6,
+        'dimensions': [SynthesizedDimension(mean, std, error_std)],
+        'seed': 0,
     }
 
     data = SynthesizedNormalMulticlassData(**params)
@@ -29,14 +29,12 @@ def _calculate_cllr(
     training_data, test_data = next(iter(data))
 
     system = TwoLevelSystem(
-        "test_system", None, pairing, None, n_trace_instances=50, n_ref_instances=50
+        'test_system', None, pairing, None, n_trace_instances=50, n_ref_instances=50
     )
     system.fit(training_data)
     llr_data: LLRData = system.apply(test_data)
-    pair_llrs = llr_data.llrs
-    pair_labels = llr_data.labels
 
-    return metrics.cllr(pair_llrs, pair_labels)
+    return metrics.cllr(llr_data)
 
 
 def test_two_level_system():

--- a/tests/test_ece.py
+++ b/tests/test_ece.py
@@ -5,6 +5,7 @@ import unittest
 
 from lir import metrics
 from lir.data.datasets.alcohol_breath_analyser import AlcoholBreathAnalyser
+from lir.data.models import LLRData
 from lir.plotting.expected_calibration_error import calculate_ece
 from lir.util import logodds_to_odds
 
@@ -12,7 +13,8 @@ from lir.util import logodds_to_odds
 class TestECE(unittest.TestCase):
     def _compare_ece_cllr(self, llrs, y):
         error = calculate_ece(logodds_to_odds(llrs), y, np.array([.5, .5]))
-        cllr = metrics.cllr(llrs, y)
+        llr_data = LLRData(features=llrs, labels=y)
+        cllr = metrics.cllr(llr_data)
         np.testing.assert_almost_equal(error[0], cllr)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 from lir import metrics
+from lir.data.models import LLRData
 from lir.metrics.devpav import devpav, _devpavcalculator, _calcsurface
 from lir.util import Xn_to_Xy, odds_to_logodds
 
@@ -25,7 +26,8 @@ from lir.util import Xn_to_Xy, odds_to_logodds
 def test_calculate_cllr(expected: float, h1_lrs: list[float], h2_lrs: list[float]):
     lrs, labels = Xn_to_Xy(np.array(h1_lrs), np.array(h2_lrs))
     llrs = odds_to_logodds(lrs)
-    pytest.approx(expected, metrics.cllr(llrs, labels))
+    llr_data = LLRData(features=llrs, labels=labels)
+    pytest.approx(expected, metrics.cllr(llr_data))
 
 
 @pytest.mark.parametrize("expected,h1_llrs,h2_llrs", [
@@ -40,7 +42,8 @@ def test_calculate_cllr(expected: float, h1_lrs: list[float], h2_lrs: list[float
 ])
 def test_extreme_cllr(expected: float, h1_llrs: list[float], h2_llrs: list[float]):
     llrs, labels = Xn_to_Xy(np.array(h1_llrs), np.array(h2_llrs))
-    pytest.approx(expected, metrics.cllr(llrs, labels))
+    llr_data = LLRData(features=llrs, labels=labels)
+    pytest.approx(expected, metrics.cllr(llr_data))
 
 
 @pytest.mark.parametrize("h1_llrs,h2_llrs", [
@@ -50,7 +53,8 @@ def test_extreme_cllr(expected: float, h1_llrs: list[float], h2_llrs: list[float
 ])
 def test_illegal_cllr(h1_llrs, h2_llrs):
     llrs, labels = Xn_to_Xy(np.array(h1_llrs), np.array(h2_llrs))
-    assert np.isnan(metrics.cllr(llrs, labels))
+    llr_data = LLRData(features=llrs, labels=labels)
+    assert np.isnan(metrics.cllr(llr_data))
 
 
 class TestDevPAV(unittest.TestCase):


### PR DESCRIPTION

An example csv has the following form:
```csv:
architecture,cllr,cllr_min,cllr_cal,llr_bounds
score_based,0.03536924351640464,0.026545075875312508,0.008824167641092135,"(-3.2700000000000005, 2.3299999999999996)"
tlm,0.10818754655217891,0.08385066569314362,0.024336880859035293,"(-1.97, 2.5000000000000004)"
```

I don't think this is the best form, as it contains a `,`. We can split it into two, but this may not be ideal either. Any suggestions for improvements? 