### PR TITLE
Rework data

### DIFF
--- a/examples/bootstrap.yaml
+++ b/examples/bootstrap.yaml
@@ -1,22 +1,22 @@
 output_path: output/${timestamp}_bootstrap
 
 data:
-  provider: synthesized_normal_binary
-  seed: 42
-  h1:
-    mean: 1
-    std: 1
-    size: 1000
-  h2:
-    mean: -1
-    std: 1
-    size: 1000
+  provider:
+    method: synthesized_normal_binary
+    seed: 42
+    h1:
+      mean: 1
+      std: 1
+      size: 1000
+    h2:
+      mean: -1
+      std: 1
+      size: 1000
 
-cross_validation_splits:
-  strategy: binary_cross_validation
-  folds: 5
-  seed: 42
-  data_origin: ${data}
+  splits:
+    strategy: binary_cross_validation
+    folds: 5
+    seed: 42
 
 lr_system:
   architecture: specific_source
@@ -38,7 +38,7 @@ experiments:
   model_selection:
     strategy: single_run
     lr_system: ${lr_system}
-    data: ${cross_validation_splits}
+    data: ${data}
     output:
       - method: csv
         columns:

--- a/examples/common_source_evaluation.yaml
+++ b/examples/common_source_evaluation.yaml
@@ -1,20 +1,20 @@
 output_path: output/${timestamp}_common_source
 
 data:
-  provider: synthesized_normal_multiclass
-  seed: 42
-  population:
-    size: 1000
-    instances_per_source: 2
-  dimensions:
-    - mean: 0
-      std: 3
-      error_std: 1
+  provider:
+    method: synthesized_normal_multiclass
+    seed: 42
+    population:
+      size: 1000
+      instances_per_source: 2
+    dimensions:
+      - mean: 0
+        std: 3
+        error_std: 1
 
-cross_validation_splits:
-  strategy: multiclass_cross_validation
-  folds: 5
-  data_origin: ${data}
+  splits:
+    strategy: multiclass_cross_validation
+    folds: 5
 
 lr_system:
   architecture: score_based
@@ -38,7 +38,7 @@ experiments:
   model_selection:
     strategy: grid
     lr_system: ${lr_system}
-    data: ${cross_validation_splits}
+    data: ${data}
     hyperparameters:
       - path: comparing.steps.clf
         options:
@@ -58,7 +58,7 @@ experiments:
   validation:
     strategy: single_run
     lr_system: ${lr_system}
-    data: ${cross_validation_splits}
+    data: ${data}
     output:
       - method: csv
         columns:

--- a/examples/glass.yaml
+++ b/examples/glass.yaml
@@ -23,13 +23,13 @@ parallel_jobs: 0
 # The data consist of a pre-defined training/test set combination. The training data has three instances per source; the
 # test data has five instances per source, from which to draw two-to-three pairs for LR calculations.
 #
-data_provider:
-  provider: data_providers.glass
-  cache_dir: cache/glass
-
 data:
-  strategy: predefined_train_test_split
-  data_origin: ${data_provider}
+  provider:
+    method: data_providers.glass
+    cache_dir: cache/glass
+
+  splits:
+    strategy: predefined_train_test_split
 
 # This defines a score-based LR system. We may later experiment with different parameter values by augmenting this
 # system.

--- a/examples/optuna.yaml
+++ b/examples/optuna.yaml
@@ -6,8 +6,12 @@
 output_path: output/${timestamp}_optuna_example
 
 data:
-  strategy: data_providers.glass
-  cache_dir: cache/glass
+  provider:
+    method: data_providers.glass
+    cache_dir: cache/glass
+
+  splits:
+    strategy: predefined_train_test_split
 
 lr_system:
   architecture: score_based

--- a/examples/specific_source_evaluation.yaml
+++ b/examples/specific_source_evaluation.yaml
@@ -1,22 +1,22 @@
 output_path: output/${timestamp}_specific_source
 
 data:
-  provider: synthesized_normal_binary
-  seed: 42
-  h1:
-    mean: 1
-    std: 1
-    size: 1000
-  h2:
-    mean: -1
-    std: 1
-    size: 1000
+  provider:
+    method: synthesized_normal_binary
+    seed: 42
+    h1:
+      mean: 1
+      std: 1
+      size: 1000
+    h2:
+      mean: -1
+      std: 1
+      size: 1000
 
-cross_validation_splits:
-  strategy: binary_cross_validation
-  folds: 5
-  seed: 42
-  data_origin: ${data}
+  splits:
+    strategy: binary_cross_validation
+    folds: 5
+    seed: 42
 
 lr_system:
   architecture: specific_source
@@ -33,7 +33,7 @@ experiments:
   model_selection:
     strategy: grid
     lr_system: ${lr_system}
-    data: ${cross_validation_splits}
+    data: ${data}
     hyperparameters:
       - path: modules.steps.clf
         options:
@@ -55,7 +55,7 @@ experiments:
   validation:
     strategy: single_run
     lr_system: ${lr_system}
-    data: ${cross_validation_splits}
+    data: ${data}
     output:
       - csv
       - pav

--- a/lir/config/data_providers.py
+++ b/lir/config/data_providers.py
@@ -19,7 +19,7 @@ def parse_data_provider(cfg: ContextAwareDict, output_path: Path) -> DataProvide
 
     Data sources are provided under the `data_sources` key.
     """
-    provider = pop_field(cfg, 'provider')
+    provider = pop_field(cfg, 'method')
 
     try:
         parser = registry.get(

--- a/lir/config/data_strategies.py
+++ b/lir/config/data_strategies.py
@@ -9,7 +9,6 @@ from lir.config.base import (
     config_parser,
     pop_field,
 )
-from lir.config.data_providers import parse_data_provider
 from lir.config.substitution import ContextAwareDict
 from lir.data.data_strategies import (
     BinaryCrossValidation,
@@ -22,30 +21,28 @@ from lir.data.models import DataStrategy
 
 def _parse_train_test_split(
     config: ContextAwareDict,
-    output_path: Path,
     constructor: Callable,
 ) -> DataStrategy:
-    data_source = parse_data_provider(pop_field(config, 'data_origin'), output_path)
     test_size = pop_field(config, 'test_size')
     seed = config.pop('seed', None)
     check_is_empty(config)
-    return constructor(data_source, test_size, seed)
+    return constructor(test_size, seed)
 
 
 @config_parser
-def binary_train_test_split(config: ContextAwareDict, output_path: Path) -> DataStrategy:
+def binary_train_test_split(config: ContextAwareDict, _: Path) -> DataStrategy:
     """
     Parse settings for a train/test split strategy for binary data.
     """
-    return _parse_train_test_split(config, output_path, BinaryTrainTestSplit)
+    return _parse_train_test_split(config, BinaryTrainTestSplit)
 
 
 @config_parser
-def multiclass_train_test_split(config: ContextAwareDict, output_path: Path) -> DataStrategy:
+def multiclass_train_test_split(config: ContextAwareDict, _: Path) -> DataStrategy:
     """
     Parse settings for a train/test split strategy for multiclass data.
     """
-    return _parse_train_test_split(config, output_path, MulticlassTrainTestSplit)
+    return _parse_train_test_split(config, MulticlassTrainTestSplit)
 
 
 def _parse_cross_validation(
@@ -55,9 +52,8 @@ def _parse_cross_validation(
     extra_args: Sequence[str],
 ) -> DataStrategy:
     folds = int(pop_field(config, 'folds'))
-    data_source = parse_data_provider(pop_field(config, 'data_origin'), output_path)
     check_is_empty(config, extra_args)
-    return constructor(data_source, folds, **config)
+    return constructor(folds, **config)
 
 
 @config_parser

--- a/lir/config/data_strategies.py
+++ b/lir/config/data_strategies.py
@@ -1,119 +1,13 @@
-from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from lir import registry
 from lir.config.base import (
     GenericConfigParser,
     YamlParseError,
-    check_is_empty,
-    config_parser,
     pop_field,
 )
 from lir.config.substitution import ContextAwareDict
-from lir.data.data_strategies import (
-    BinaryCrossValidation,
-    BinaryTrainTestSplit,
-    MulticlassCrossValidation,
-    MulticlassTrainTestSplit,
-)
 from lir.data.models import DataStrategy
-
-
-def _parse_train_test_split(
-    config: ContextAwareDict,
-    constructor: Callable,
-) -> DataStrategy:
-    test_size = pop_field(config, 'test_size')
-    seed = config.pop('seed', None)
-    check_is_empty(config)
-    return constructor(test_size, seed)
-
-
-@config_parser
-def binary_train_test_split(config: ContextAwareDict, _: Path) -> DataStrategy:
-    """
-    Parse settings for a train/test split strategy for binary data.
-    """
-    return _parse_train_test_split(config, BinaryTrainTestSplit)
-
-
-@config_parser
-def multiclass_train_test_split(config: ContextAwareDict, _: Path) -> DataStrategy:
-    """
-    Parse settings for a train/test split strategy for multiclass data.
-    """
-    return _parse_train_test_split(config, MulticlassTrainTestSplit)
-
-
-def _parse_cross_validation(
-    config: ContextAwareDict,
-    output_path: Path,
-    constructor: Callable,
-    extra_args: Sequence[str],
-) -> DataStrategy:
-    folds = int(pop_field(config, 'folds'))
-    check_is_empty(config, extra_args)
-    return constructor(folds, **config)
-
-
-@config_parser
-def binary_cross_validation(config: ContextAwareDict, output_path: Path) -> DataStrategy:
-    """Initialize K-fold cross validation strategy by parsing the configuration for binary classes.
-
-    This method might be referenced in the YAML registry as follows:
-    ```
-    data_setup:
-      binary_cross_validation: lir.config.data_setup.binary_cross_validation
-    ```
-
-    In the benchmark configuration YAML, this validation can be referenced as follows:
-    ```
-    binary_cross_validation_splits:
-        strategy: binary_cross_validation
-        data_origin: ${data}
-    ```
-
-    which is ultimately passed through the benchmark definition:
-    ```
-    benchmarks:
-      model_selection_run:
-        strategy: grid
-        lr_system: ${lr_system}
-        data_origin: ${binary_cross_validation_splits}
-        ...
-    """
-    return _parse_cross_validation(config, output_path, BinaryCrossValidation, ['seed'])
-
-
-@config_parser
-def multiclass_cross_validation(config: ContextAwareDict, output_path: Path) -> DataStrategy:
-    """Initialize K-fold cross validation strategy by parsing the configuration for multiple classes.
-
-    This method might be referenced in the YAML registry as follows:
-    ```
-    data_setup:
-      multiclass_cross_validation: lir.config.data_setup.multiclass_cross_validation
-    ```
-
-    In the benchmark configuration YAML, this validation can be referenced as follows:
-    ```
-    cross_validation_splits:
-        strategy: multiclass_cross_validation
-        folds: 5
-        data_origin: ${data}
-    ```
-
-    which is ultimately passed through the benchmark definition:
-    ```
-    benchmarks:
-      model_selection_run:
-        strategy: grid
-        lr_system: ${lr_system}
-        data: ${cross_validation_splits}
-        ...
-    ```
-    """
-    return _parse_cross_validation(config, output_path, MulticlassCrossValidation, [])
 
 
 def parse_data_strategy(cfg: ContextAwareDict, output_path: Path) -> DataStrategy:

--- a/lir/data/data_strategies.py
+++ b/lir/data/data_strategies.py
@@ -11,8 +11,8 @@ from lir.data.models import DataStrategy, FeatureData
 class BinaryTrainTestSplit(DataStrategy):
     """Representation of a train/test split.
 
-    The input data should have class labels. This split assigns instances of both classes to the training set and the
-    test set.
+    The input data should have hypothesis labels. This split assigns instances of both classes to the training set and
+    the test set.
     """
 
     def __init__(self, test_size: float | int, seed: int | None = None):
@@ -33,6 +33,18 @@ class BinaryCrossValidation(DataStrategy):
     """Representation of a K-fold cross validation iterator over each train/test split fold.
 
     The input data should have class labels. This split assigns instances of both classes to each "fold" subset.
+
+    This method might be referenced in the YAML registry as follows:
+    ```
+    data_strategies:
+      binary_cross_validation: lir.data.data_strategies.BinaryCrossValidation
+    ```
+
+    In the benchmark configuration YAML, this validation can be referenced as follows:
+    ```
+    splits:
+      strategy: binary_cross_validation
+    ```
     """
 
     def __init__(self, folds: int, seed: int | None = None):
@@ -67,9 +79,25 @@ class MulticlassTrainTestSplit(DataStrategy):
 
 
 class MulticlassCrossValidation(DataStrategy):
-    """Representation of a K-fold cross validation iterator over each train/test split fold.
+    """
+    Representation of a K-fold cross validation iterator over train/test splits.
 
     The input data should have source_ids. This split assigns all instances of a source to the same "fold" subset.
+
+    This method might be referenced in the YAML registry as follows:
+    ```
+    data_strategies:
+      multiclass_cross_validation: lir.data.data_strategies.MulticlassCrossValidation
+    ```
+
+    In the benchmark configuration YAML, this validation can be referenced as follows:
+    ```
+    data:
+      [...]
+      splits:
+        strategy: multiclass_cross_validation
+        folds: 5
+    ```
     """
 
     def __init__(self, folds: int):

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -412,15 +412,16 @@ class DataProvider(ABC):
         raise NotImplementedError
 
 
-class DataStrategy(ABC, Iterable[tuple[FeatureData, FeatureData]]):
+class DataStrategy(ABC):
     """
-    General representation of a data setup strategy.
-
-    All subclasses must implement a `__iter__()` method.
-
-    The custom __iter__() method should return an iterator over tuples
-    of a training set and a test set. Both the training set and the test
-    is represented by an `InstanceData` object.
+    Base class for data strategies.
     """
 
-    pass
+    @abstractmethod
+    def apply(self, instances: FeatureData) -> Iterable[tuple[FeatureData, FeatureData]]:
+        """
+        Returns an iterator over tuples of a training set and a test set. Both the training set and the test
+        is represented by an `InstanceData` object.
+        """
+
+        raise NotImplementedError

--- a/lir/optuna.py
+++ b/lir/optuna.py
@@ -12,7 +12,7 @@ from lir.config.substitution import (
     Hyperparameter,
     HyperparameterOption,
 )
-from lir.data.models import DataStrategy
+from lir.data.models import DataProvider, DataStrategy
 from lir.experiment import Experiment
 
 
@@ -22,7 +22,8 @@ class OptunaExperiment(Experiment):
     def __init__(
         self,
         name: str,
-        data: DataStrategy,
+        data_provider: DataProvider,
+        splitter: DataStrategy,
         outputs: Sequence[Aggregation],
         output_path: Path,
         baseline_config: ContextAwareDict,
@@ -30,7 +31,7 @@ class OptunaExperiment(Experiment):
         n_trials: int,
         metric_function: Callable,
     ):
-        super().__init__(name, data, outputs, output_path)
+        super().__init__(name, data_provider, splitter, outputs, output_path)
         self.baseline_config = baseline_config
         self.hyperparameters = hyperparameters
         self.n_trials = n_trials

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -7,10 +7,10 @@ experiment_strategies:
   grid: lir.config.experiment_strategies.GridStrategy
   optuna: lir.config.experiment_strategies.OptunaStrategy
 data_strategies:
-  binary_train_test_split: lir.config.data_strategies.binary_train_test_split
-  binary_cross_validation: lir.config.data_strategies.binary_cross_validation
-  multiclass_train_test_split: lir.config.data_strategies.multiclass_train_test_split
-  multiclass_cross_validation: lir.config.data_strategies.multiclass_cross_validation
+  binary_train_test_split: lir.data.data_strategies.BinaryTrainTestSplit
+  binary_cross_validation: lir.data.data_strategies.BinaryCrossValidation
+  multiclass_train_test_split: lir.data.data_strategies.MulticlassTrainTestSplit
+  multiclass_cross_validation: lir.data.data_strategies.MulticlassCrossValidation
   predefined_train_test_split: lir.data.data_strategies.PredefinedTrainTestSplit
 data_providers:
   synthesized_normal_binary: lir.data.datasets.synthesized_normal_binary.synthesized_normal_binary

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -11,7 +11,7 @@ data_strategies:
   binary_cross_validation: lir.config.data_strategies.binary_cross_validation
   multiclass_train_test_split: lir.config.data_strategies.multiclass_train_test_split
   multiclass_cross_validation: lir.config.data_strategies.multiclass_cross_validation
-  predefined_train_test_split: lir.data.data_strategies.predefined_train_test_split
+  predefined_train_test_split: lir.data.data_strategies.PredefinedTrainTestSplit
 data_providers:
   synthesized_normal_binary: lir.data.datasets.synthesized_normal_binary.synthesized_normal_binary
   synthesized_normal_multiclass: lir.data.datasets.synthesized_normal_multiclass.synthesized_normal_multiclass

--- a/tests/lrsystems/test_specific_source.py
+++ b/tests/lrsystems/test_specific_source.py
@@ -16,7 +16,7 @@ from lir.transform.pipeline import Pipeline
 
 def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBinaryData):
     """Check that a simple Specific Source LR system can be utilized through a SKLearn pipeline."""
-    data = BinaryTrainTestSplit(synthesized_normal_data, 0.2, seed=0)
+    splitter = BinaryTrainTestSplit(0.2, seed=0)
 
     steps = [
         ("preprocessing", StandardScaler()),
@@ -25,7 +25,7 @@ def test_specific_source_pipeline(synthesized_normal_data: SynthesizedNormalBina
     pipeline = Pipeline(steps)
 
     specific_source_system = BinaryLRSystem("test_system", pipeline)
-    data_train, data_test = next(iter(data))
+    data_train, data_test = next(iter(splitter.apply(synthesized_normal_data.get_instances())))
     specific_source_system.fit(data_train)
     llr_data: LLRData = specific_source_system.apply(data_test)
 

--- a/tests/lrsystems/test_two_level.py
+++ b/tests/lrsystems/test_two_level.py
@@ -22,11 +22,11 @@ def _calculate_cllr(
     }
 
     data = SynthesizedNormalMulticlassData(**params)
-    data = MulticlassCrossValidation(data, 2)
+    splitter = MulticlassCrossValidation(2)
 
     pairing = SourcePairing(seed=0)
 
-    training_data, test_data = next(iter(data))
+    training_data, test_data = next(iter(splitter.apply(data.get_instances())))
 
     system = TwoLevelSystem(
         "test_system", None, pairing, None, n_trace_instances=50, n_ref_instances=50

--- a/tests/resources/setup.yaml
+++ b/tests/resources/setup.yaml
@@ -1,21 +1,21 @@
 output_path: output/${timestamp}_specific_source
 
 data:
-  provider: synthesized_normal_binary
-  seed: 42
-  h1:
-    mean: 1
-    std: 1
-    size: 100
-  h2:
-    mean: -1
-    std: 1
-    size: 100
+  provider:
+    method: synthesized_normal_binary
+    seed: 42
+    h1:
+      mean: 1
+      std: 1
+      size: 100
+    h2:
+      mean: -1
+      std: 1
+      size: 100
 
-data_splits:
-  strategy: binary_train_test_split
-  test_size: 0.5
-  data_origin: ${data}
+  splits:
+    strategy: binary_train_test_split
+    test_size: 0.5
 
 lr_system:
   architecture: specific_source
@@ -28,7 +28,7 @@ experiments:
   exp1:
     strategy: grid
     lr_system: ${lr_system}
-    data: ${data_splits}
+    data: ${data}
     hyperparameters:
       - path: modules.steps.clf
         options:
@@ -45,7 +45,7 @@ experiments:
   exp2:
     strategy: single_run
     lr_system: ${lr_system}
-    data: ${data_splits}
+    data: ${data}
     output:
       - method: csv
         columns:

--- a/tests/test_data_strategies.py
+++ b/tests/test_data_strategies.py
@@ -13,9 +13,9 @@ def test_multiclass_train_test_split():
     data = SynthesizedNormalMulticlassData(
         population_size=100, sources_size=3, seed=0, dimensions=dimensions
     )
-    strategy = MulticlassTrainTestSplit(data, test_size=0.5, seed=0)
+    strategy = MulticlassTrainTestSplit(test_size=0.5, seed=0)
     instances = data.get_instances()
-    for data_train, data_test in strategy:
+    for data_train, data_test in strategy.apply(instances):
         assert len(np.unique(data_train.source_ids)) + len(np.unique(data_test.source_ids)) == len(
             np.unique(instances.source_ids)
         )
@@ -26,40 +26,32 @@ def test_multiclass_train_test_split_seed():
     dimensions = [SynthesizedDimension(0, 1, 0.2), SynthesizedDimension(0, 1, 0.2)]
     data = SynthesizedNormalMulticlassData(
         population_size=100, sources_size=3, seed=0, dimensions=dimensions
-    )
+    ).get_instances()
 
-    ref_strategy = MulticlassTrainTestSplit(data, test_size=0.5, seed=0)
-    ref_train, ref_test = next(iter(ref_strategy))
+    ref_strategy = MulticlassTrainTestSplit(test_size=0.5, seed=0)
+    ref_train, ref_test = next(iter(ref_strategy.apply(data)))
 
     # test:
     # - another MulticlassTrainTestSplit instance with the same seed should yield the same results
     # - the same instance should yield the same results twice
-    strategies = [MulticlassTrainTestSplit(data, test_size=0.5, seed=0)] * 2
+    strategies = [MulticlassTrainTestSplit(test_size=0.5, seed=0)] * 2
     for strategy in strategies:
-        for data_train, data_test in strategy:
+        for data_train, data_test in strategy.apply(data):
             assert data_train == ref_train
             assert data_test == ref_test
 
     # test:
     # - another MulticlassTrainTestSplit instance with another seed should yield different results
-    strategy = MulticlassTrainTestSplit(data, test_size=0.5, seed=1)
-    for data_train, data_test in strategy:
+    strategy = MulticlassTrainTestSplit(test_size=0.5, seed=1)
+    for data_train, data_test in strategy.apply(data):
         assert not data_train == ref_train
         assert not data_test == ref_test
 
 
-class _MemoryDataProvider(DataProvider):
-    def __init__(self, instances: InstanceData):
-        self.instances = instances
-
-    def get_instances(self) -> InstanceData:
-        return self.instances
-
-
 def test_predefined_role_splitter():
     instances = FeatureData(features=np.arange(16).reshape(-1, 2), role_assignments=np.array(["train", "test"]).repeat(4))
-    splitter = PredefinedTrainTestSplit(_MemoryDataProvider(instances))
-    splits = list(splitter)
+    splitter = PredefinedTrainTestSplit()
+    splits = list(splitter.apply(instances))
     assert len(splits) == 1, "exactly one split"
 
     training_set, test_set = splits[0]


### PR DESCRIPTION
YAML ziet er nu zo uit:

```
data:
  provider:
    method: glass_loader
  splits:
    strategy: predefined_train_test_split
```

wijzigingen:

- redesigned data section in YAML
- in DataStrategy, replace __iter__() by something with an argument, like def apply(instances: InstanceData) -> Iterator[tuple[InstanceData, InstanceData]]
- remove the DataProvider argument from DataStrategy constructors
- removed config parsers that are no longer necessary


closes #144 