### PR TITLE
remove parameters attribute from class LRSystem

### DIFF
--- a/lir/config/experiment_strategies.py
+++ b/lir/config/experiment_strategies.py
@@ -126,7 +126,7 @@ class SingleRunStrategy(ExperimentStrategyConfigParser):
             self.data(),
             self.output_list(),
             self._output_dir,
-            [lrsystem],
+            [(lrsystem, {})],
         )
 
 
@@ -142,7 +142,7 @@ class GridStrategy(ExperimentStrategyConfigParser):
         for value_set in product(*values):
             substitutions = dict(zip(names, value_set, strict=True))
             lrsystem = parse_augmented_lrsystem(baseline_config, substitutions, self._output_dir)
-            lrsystems.append(lrsystem)
+            lrsystems.append((lrsystem, substitutions))
 
         return PredefinedExperiment(
             name,

--- a/lir/config/lrsystem_architectures.py
+++ b/lir/config/lrsystem_architectures.py
@@ -118,5 +118,4 @@ def parse_augmented_lrsystem(
         augmented_config,
         output_dir / f'{dirname_prefix}{name}',
     )
-    lrsystem.parameters = hyperparameters
     return lrsystem

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Any
 
 from lir.data.models import FeatureData, LLRData
 
@@ -9,7 +8,6 @@ class LRSystem(ABC):
 
     def __init__(self, name: str):
         self.name = name
-        self.parameters: dict[str, Any] = {}
 
     def fit(self, instances: FeatureData) -> 'LRSystem':
         """

--- a/lir/optuna.py
+++ b/lir/optuna.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any
 
 import optuna
 
@@ -68,7 +69,8 @@ class OptunaExperiment(Experiment):
         )
 
         # add optuna values as system parameters
-        lrsystem.parameters.update(
+        hyperparamters: dict[str, Any] = assignments
+        hyperparamters.update(
             {
                 # trial.number is a sequence number, starting at 0
                 'trial': trial.number,
@@ -77,7 +79,7 @@ class OptunaExperiment(Experiment):
             }
         )
 
-        llrs = self._run_lrsystem(lrsystem)
+        llrs = self._run_lrsystem(lrsystem, hyperparamters)
         return self.metric_function(llrs.llrs, llrs.labels)
 
     def _generate_and_run(self) -> None:


### PR DESCRIPTION
om de code iets overzichtelijker te maken, want hoe de hyperparameters er nu inzitten is niet logisch

voorheen:
- lrsystem wordt gebouwd
- parameters worden er achteraf aan toegevoegd
- parameters worder er weer uitgetrokken waar nodig

nu:
- lrsystem wordt gebouwd
- parameters worden opgeslagen in AggregationData