### PR TITLE
Relax transformer api

### DIFF
--- a/lir/bounding.py
+++ b/lir/bounding.py
@@ -5,7 +5,8 @@ from typing import Self
 import numpy as np
 
 from lir import Transformer
-from lir.data.models import FeatureData, LLRData
+from lir.data.models import FeatureData, InstanceData, LLRData
+from lir.util import check_type
 
 
 LOG = logging.getLogger(__name__)
@@ -35,13 +36,14 @@ class LLRBounder(Transformer, ABC):
         raise NotImplementedError
 
     @staticmethod
-    def _validate(instances: FeatureData) -> LLRData:
+    def _validate(instances: InstanceData) -> LLRData:
+        instances = check_type(FeatureData, instances)
         if not isinstance(instances, LLRData):
             LOG.info(f'casting `{type(instances)}` to `LLRData`')
             instances = instances.replace_as(LLRData)
         return instances
 
-    def fit(self, instances: FeatureData) -> Self:
+    def fit(self, instances: InstanceData) -> Self:
         """
         Configures this bounder by calculating bounds.
 
@@ -68,7 +70,7 @@ class LLRBounder(Transformer, ABC):
 
         return self
 
-    def transform(self, instances: FeatureData) -> LLRData:
+    def transform(self, instances: InstanceData) -> LLRData:
         """
         a transform entails calling the first step calibrator and applying the bounds found
         """

--- a/lir/data/datasets/feature_data_csv.py
+++ b/lir/data/datasets/feature_data_csv.py
@@ -12,10 +12,11 @@ import numpy as np
 import requests
 from requests_cache import CachedSession
 
-from lir.config.base import ContextAwareDict, check_type, config_parser, pop_field
+from lir.config.base import ContextAwareDict, config_parser, pop_field
 from lir.data.data_strategies import RoleAssignment
 from lir.data.io import search_path
 from lir.data.models import DataProvider, FeatureData
+from lir.util import check_type
 
 
 LOG = logging.getLogger(__name__)

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -1,4 +1,7 @@
+from typing import Self
+
 from lir import Transformer
+from lir.data.models import InstanceData
 from lir.lrsystems.lrsystems import FeatureData, LLRData, LRSystem
 from lir.transform.pairing import PairingMethod
 from lir.transform.pipeline import Pipeline
@@ -25,7 +28,7 @@ class ScoreBasedSystem(LRSystem):
         self.pairing_function = pairing_function
         self.evaluation_pipeline = evaluation_pipeline or Pipeline([])
 
-    def fit(self, instances: FeatureData) -> 'LRSystem':
+    def fit(self, instances: InstanceData) -> Self:
         instances = self.preprocessing_pipeline.fit_transform(instances)
         pairs = self.pairing_function.pair(instances, 1, 1)
         self.evaluation_pipeline.fit(pairs)

--- a/lir/metrics/__init__.py
+++ b/lir/metrics/__init__.py
@@ -26,7 +26,7 @@ def cllr(llrs: np.ndarray, y: np.ndarray, weights: tuple[float, float] = (1, 1))
         lrs0, lrs1 = Xy_to_Xn(lrs, y)
         cllr0 = weights[0] * np.mean(np.log2(1 + lrs0)) if weights[0] > 0 else 0
         cllr1 = weights[1] * np.mean(np.log2(1 + 1 / lrs1)) if weights[1] > 0 else 0
-        return (cllr0 + cllr1) / sum(weights)
+        return float((cllr0 + cllr1) / sum(weights))
 
 
 def cllr_min(llrs: np.ndarray, y: np.ndarray, weights: tuple[float, float] = (1, 1)) -> float:

--- a/lir/transform/pairing.py
+++ b/lir/transform/pairing.py
@@ -3,8 +3,9 @@ from typing import Any
 
 import numpy as np
 
-from lir.data.models import PairedFeatureData, concatenate_instances
+from lir.data.models import InstanceData, PairedFeatureData, concatenate_instances
 from lir.lrsystems.lrsystems import FeatureData
+from lir.util import check_type
 
 
 class PairingMethod(ABC):
@@ -17,9 +18,9 @@ class PairingMethod(ABC):
     @abstractmethod
     def pair(
         self,
-        instances: FeatureData,
-        n_trace_instances: int = 1,
-        n_ref_instances: int = 1,
+        instances: InstanceData,
+        n_trace_instances: int,
+        n_ref_instances: int,
     ) -> PairedFeatureData:
         """
         Takes instances as input, and returns pairs.
@@ -126,7 +127,7 @@ class SourcePairing(PairingMethod):
 
     def pair(
         self,
-        instances: FeatureData,
+        instances: InstanceData,
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
     ) -> PairedFeatureData:
@@ -144,6 +145,8 @@ class SourcePairing(PairingMethod):
         :param n_ref_instances: the number of reference instances in each pair
         :return: paired instances
         """
+        instances = check_type(FeatureData, instances)
+
         if instances.source_ids is None:
             raise ValueError('pairing requires source_ids')
 
@@ -242,7 +245,7 @@ class InstancePairing(PairingMethod):
 
     def pair(
         self,
-        instances: FeatureData,
+        instances: InstanceData,
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
     ) -> PairedFeatureData:
@@ -254,6 +257,7 @@ class InstancePairing(PairingMethod):
         :param n_ref_instances: the number of reference instances in each pair (must be 1 for this pairing method)
         :return: paired instances
         """
+        instances = check_type(FeatureData, instances)
         if instances.source_ids is None:
             raise ValueError('pairing requires source_ids')
 

--- a/lir/util.py
+++ b/lir/util.py
@@ -10,6 +10,13 @@ import numpy as np
 LR = collections.namedtuple('LR', ['lr', 'p0', 'p1'])
 
 
+def check_type(type_class: Any, v: Any) -> Any:
+    if isinstance(v, type_class):
+        return v
+    else:
+        raise ValueError(f'expected type: {type_class}; found: {type(v)}')
+
+
 def get_classes_from_Xy(X: np.ndarray, y: np.ndarray, classes: list[Any] | None = None) -> np.ndarray:
     assert len(X.shape) >= 1, f'expected: X has at least 1 dimensions; found: {len(X.shape)} dimensions'
     assert len(y.shape) == 1, f'expected: y is a 1-dimensional array; found: {len(y.shape)} dimensions'

--- a/lir/util.py
+++ b/lir/util.py
@@ -10,11 +10,15 @@ import numpy as np
 LR = collections.namedtuple('LR', ['lr', 'p0', 'p1'])
 
 
-def check_type(type_class: Any, v: Any) -> Any:
+AnyType = TypeVar('AnyType', bound=Any)
+
+
+def check_type(type_class: type[AnyType], v: Any, message: str | None = None) -> AnyType:
     if isinstance(v, type_class):
         return v
     else:
-        raise ValueError(f'expected type: {type_class}; found: {type(v)}')
+        message = message or f'expected type: {type_class}'
+        raise ValueError(f'{message}; found: {type(v)}')
 
 
 def get_classes_from_Xy(X: np.ndarray, y: np.ndarray, classes: list[Any] | None = None) -> np.ndarray:


### PR DESCRIPTION
Most of the data handling classes use FeatureData objects, which is fine as long as we have features.

To support other data types such as text, we have InstanceData, but the API should be changed to support this.

This PR updates the Transformer class. DataProvider, DataStrategy and LRSystem should follow later.

see #160 