### PR TITLE
ECE Plot: add option to remove 'after PAV'-line  / adjust y-range 

### DIFF
--- a/examples/specific_source_evaluation.yaml
+++ b/examples/specific_source_evaluation.yaml
@@ -54,6 +54,7 @@ experiments:
         show_pav: false
       - method: ece
         show_pav: true
+        ylim: zoomed
 
 
   validation:

--- a/examples/specific_source_evaluation.yaml
+++ b/examples/specific_source_evaluation.yaml
@@ -50,7 +50,11 @@ experiments:
         - cllr_min
         - cllr_cal
       - pav
-      - ece
+      - method: ece
+        show_pav: false
+      - method: ece
+        show_pav: true
+
 
   validation:
     strategy: single_run
@@ -64,4 +68,5 @@ experiments:
         plot_type: 1
       - method: tippett
         plot_type: 2
+
 

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -99,7 +99,7 @@ def plot_pav(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
 
 @config_parser
 def plot_ece(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    return AggregatePlot(output_dir=output_dir, plot_fn=ece, plot_name='ECE')
+    return AggregatePlot(output_dir=output_dir, plot_fn=ece, plot_name='ECE', **config)
 
 
 @config_parser

--- a/lir/plotting/expected_calibration_error.py
+++ b/lir/plotting/expected_calibration_error.py
@@ -50,8 +50,11 @@ def plot_ece(
         indicating both ends of the range on the x-axis)
     :param ax: the matplotlib axis to plot on
     :param show_pav: whether to show the PAV-transformed LRs in the plot
-    :param ylim: the y-axis limits; either 'neutral' (starts at 0) or 'zoomed'
-        (starts at 0 and ends slightly above the maximum ECE value of the LRs)
+    :param ylim: the y-axis limits. Valid values are:
+        - 'neutral':  starts at 0, and ends automatically. In practice, this means that the upper limit is set slightly
+                      above the maximum of the 'non-informative' reference.
+        - 'zoomed':   starts at 0 and ends slightly (10%) above the maximum ECE value of the LRs. This may cut off part
+                       of the 'non-informative' reference line.
     """
     llrs = llrdata.llrs
     labels = llrdata.labels

--- a/lir/plotting/expected_calibration_error.py
+++ b/lir/plotting/expected_calibration_error.py
@@ -29,7 +29,9 @@ from lir.util import (
 )
 
 
-def plot_ece(llrdata: LLRData, log_prior_odds_range: tuple[float, float] = (-3, 3), ax: Any = plt) -> None:
+def plot_ece(
+    llrdata: LLRData, log_prior_odds_range: tuple[float, float] = (-3, 3), ax: Any = plt, show_pav: bool = True
+) -> None:
     """
     Generates an ECE plot for a set of LRs and corresponding ground-truth
     labels.
@@ -39,11 +41,11 @@ def plot_ece(llrdata: LLRData, log_prior_odds_range: tuple[float, float] = (-3, 
     line), (2) the set of LR values (line), and (3) the set of LR values after
     PAV-transformation (Pool Adjacent Violators, dashed line).
 
-    :param lrs: an array of LRs
-    :param labels: an array of ground-truth labels (values 0 for Hd or 1 for Hp);
-        must be of the same length as `lrs`
+    :param llrdata: the LLR data containing LLRs and labels.
     :param log_prior_odds_range: the range of prior odds (tuple of two values,
         indicating both ends of the range on the x-axis)
+    :param ax: the matplotlib axis to plot on
+    :param show_pav: whether to show the PAV-transformed LRs in the plot
     """
     llrs = llrdata.llrs
     labels = llrdata.labels
@@ -70,14 +72,15 @@ def plot_ece(llrdata: LLRData, log_prior_odds_range: tuple[float, float] = (-3, 
         label='LRs',
     )
 
-    # plot PAV LRs
-    pav_llrs = IsotonicCalibrator().fit_transform(llrs, labels)
-    ax.plot(
-        log_prior_odds,
-        calculate_ece(logodds_to_odds(pav_llrs), labels, odds_to_probability(prior_odds)),
-        linestyle='--',
-        label='PAV LRs',
-    )
+    if show_pav:
+        # plot PAV LRs
+        pav_llrs = IsotonicCalibrator().fit_transform(llrs, labels)
+        ax.plot(
+            log_prior_odds,
+            calculate_ece(logodds_to_odds(pav_llrs), labels, odds_to_probability(prior_odds)),
+            linestyle='--',
+            label='PAV LRs',
+        )
 
     ax.set_xlabel('prior log$_{10}$(odds)')
     ax.set_ylabel('empirical cross-entropy')


### PR DESCRIPTION
Closes #86

Based on #166 


`show_pav = False`:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/32415043-4c31-4152-8f8a-8fa142eadc27" />



`ylim = 'zoomed':
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/68f484e5-0ff6-47ff-8417-a83691ee8160" />
