### PR TITLE
Replace 'abs_diff' with 'element_wise_difference'

### DIFF
--- a/examples/optuna.yaml
+++ b/examples/optuna.yaml
@@ -25,7 +25,7 @@ lr_system:
   comparing:
     steps:
       scoring:
-        method: abs_diff
+        method: element_wise_difference
       clf:
         method: logistic_regression
         random_state: 0


### PR DESCRIPTION
In addition to the replaced `abs_diff` method in the patch to replace `AbsDiffTransformer` by `ElementWiseDifference`, the `optuna.yaml` example experiment has not been updated yet.

Fixes 24aaa17.