### PR TITLE
run checks on specific folders only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ all = {composite = ["check", "test"]}
 all_with_quicktest = {composite = ["check", "quicktest"]}
 check = {composite = ["format-check", "lint", "mypy"]}
 fix-all = {composite = ["lint-fix", "format-fix"]}
-lint = "ruff check ."
-lint-fix = "ruff check --fix ."
-format-check = "ruff format --diff ."
-format-fix = "ruff format ."
+lint = "ruff check lir tests"
+lint-fix = "ruff check --fix lir tests"
+format-check = "ruff format --diff lir tests"
+format-fix = "ruff format lir tests"
 mypy = "mypy lir"
 # If no args are given to 'test', this will run as if '{args}' is an empty string.
 test = "coverage run --branch --source lir --module pytest --strict-markers tests/ {args}"


### PR DESCRIPTION
Dit helpt, omdat je dan wat rommel in de root kwijt kan dat je niet wil inchecken