### PR TITLE
csv parser supports reading pair data by reading two source id columns

### DIFF
--- a/lir/data/data_strategies.py
+++ b/lir/data/data_strategies.py
@@ -107,7 +107,7 @@ class MulticlassCrossValidation(DataStrategy):
         """Allow iteration by looping over the resulting train/test split(s)."""
         kf = GroupKFold(n_splits=self.folds)
 
-        for _i, (train_index, test_index) in enumerate(kf.split(instances.features, groups=instances.source_ids)):
+        for _i, (train_index, test_index) in enumerate(kf.split(instances.features, groups=instances.source_ids_1d)):
             yield instances[train_index], instances[test_index]
 
 

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -460,11 +460,8 @@ class TwoLevelSystem(LRSystem):
 
     def fit(self, instances: InstanceData) -> Self:
         """Fit the model based on the instance data."""
-        if instances.source_ids is None:
-            raise ValueError('fit() requires source_ids')
-
         instances = self.preprocessing_pipeline.fit_apply(instances)
-        self.model.fit_on_unpaired_instances(instances.features, instances.source_ids)
+        self.model.fit_on_unpaired_instances(instances.features, instances.source_ids_1d)
 
         pairs = self.pairing_function.pair(instances, self.n_trace_instances, self.n_ref_instances)
         pair_llrs = pairs.replace_as(LLRData, features=self.model.transform(pairs.features_trace, pairs.features_ref))

--- a/tests/data/datasets/test_csv_parser.py
+++ b/tests/data/datasets/test_csv_parser.py
@@ -64,6 +64,24 @@ from lir.data.models import FeatureData
             '1 row, 2 features, with label, source_id',
         ),
         (
+            'source_id0,source_id1,feature1,feature2\n10,11,1,1\n',
+            {'source_id_column': ['source_id0', 'source_id1']},
+            FeatureData(source_ids=np.array([['10', '11']]), features=np.ones((1, 2))),
+            '1 row, two source_id columns',
+        ),
+        (
+            'source_id0,source_id1,feature1,feature2\n10,11,1,1\n',
+            {'source_id_column': ['source_id0', 'source_id2']},
+            None,
+            '1 row, invalid source_id column',
+        ),
+        (
+            'source_id0,source_id1,source_id2,feature1,feature2\n10,11,12,1,1\n',
+            {'source_id_column': ['source_id0', 'source_id1', 'source_id2']},
+            None,
+            '1 row, three source_id columns',
+        ),
+        (
             'source_id,instance_id,feature1,feature2\n10,11,1,1\n',
             {'instance_id_column': 'instance_id', 'source_id_column': 'source_id'},
             FeatureData(source_ids=np.array(['10']), instance_ids=np.array(['11']), features=np.ones((1, 2))),

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -34,9 +34,9 @@ def test_instance_data():
     assert BareData(labels=np.ones((10,)), meta=2) != BareData(labels=np.ones((10,)))
 
     # test slicing
-    assert np.all(BareData(source_ids=np.arange(10))[:5].source_ids == np.arange(5))
+    assert np.all(BareData(source_ids=np.arange(10))[:5].source_ids_1d == np.arange(5))
     assert np.all(BareData(labels=np.repeat([0, 1, 0, 1], 2))[:5].labels == np.array([0, 0, 1, 1, 0]))
-    assert BareData(source_ids=np.arange(10))[8:9].source_ids == np.array([8])
+    assert BareData(source_ids=np.arange(10))[8:9].source_ids_1d == np.array([8])
 
     # illegal labels type
     with pytest.raises(ValidationError):

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -33,7 +33,7 @@ def test_instance_pairing_seed():
             np.array([[0, 1]]),  # pair indices
             1,
             np.ones((3, 1)),  # features
-            np.arange(3),  # labels
+            np.arange(3),  # source_ids
             1,
             1,
         ),
@@ -41,7 +41,7 @@ def test_instance_pairing_seed():
             np.array([[0, 1], [0, 2]]),  # pair indices
             2,
             np.ones((3, 1)),  # features
-            np.arange(3),  # labels
+            np.arange(3),  # source_ids
             1,
             1,
         ),
@@ -49,7 +49,7 @@ def test_instance_pairing_seed():
             np.array([[0, 0]]),  # pair indices
             0,
             np.ones((3, 1)),
-            np.arange(3),
+            np.arange(3),  # source_ids
             1,
             1,
         ),
@@ -57,7 +57,7 @@ def test_instance_pairing_seed():
             np.array([[0, 0]]),  # pair indices
             1,
             np.ones((10, 1)),  # features
-            np.zeros(10),  # labels
+            np.zeros(10),  # source_ids
             1,
             1,
         ),
@@ -65,7 +65,7 @@ def test_instance_pairing_seed():
             np.array([[0, 0], [1, 1]]),  # pair indices
             1,
             np.ones((10, 1)),  # features
-            np.zeros(10),  # labels
+            np.zeros(10),  # source_ids
             1,
             1,
         ),
@@ -73,7 +73,7 @@ def test_instance_pairing_seed():
             np.array([[0, 0]]),  # pair indices
             1,
             np.ones((10, 1)),  # features
-            np.zeros(10),  # labels
+            np.zeros(10),  # source_ids
             4,
             6,
         ),
@@ -81,7 +81,7 @@ def test_instance_pairing_seed():
             np.array([[0, 0]]),  # pair indices
             0,
             np.ones((10, 1)),  # features
-            np.zeros(10),  # labels
+            np.zeros(10),  # source_ids
             5,
             6,
         ),


### PR DESCRIPTION
De property `source_ids` heeft nu meer validatie en kent expliciet twee vormen, namelijk voor enkele instances en voor pairs.

closes #273 