### PR TITLE
Subset aggregation

### DIFF
--- a/lir/config/aggregation.py
+++ b/lir/config/aggregation.py
@@ -1,0 +1,70 @@
+from functools import partial
+from pathlib import Path
+
+from lir import registry
+from lir.aggregation import Aggregation
+from lir.config.base import (
+    ConfigParser,
+    ContextAwareDict,
+    ContextAwareList,
+    GenericConfigParser,
+    YamlParseError,
+    check_type,
+    pop_field,
+)
+
+
+def parse_aggregation(
+    config: ContextAwareDict | str, output_dir: Path, context: list[str] | None = None
+) -> Aggregation:
+    """
+    Parse a configuration section for output aggregation.
+
+    If `config` is a dictionary, the `method` property is the aggregation method that is looked up in the registry.
+    Other properties are passed as parameters. If `config` is a `str`, then its value is the aggregation method, and it
+    has no parameters.
+
+    :param config: the configuration as a dictionary or str
+    :param output_dir: the output directory
+    :param context: the context cof the configuration (if `config` is a str)
+    :return: an Aggregation object
+    """
+    # Normalise configuration into (class_name, args)
+    if isinstance(config, str):
+        config = ContextAwareDict(context or [], {'method': config})
+    check_type(dict, config, 'invalid output configuration; expected a string or a mapping with a "method" field')
+
+    class_name = pop_field(config, 'method', validate=partial(check_type, str))
+
+    parser: ConfigParser = registry.get(
+        class_name,
+        default_config_parser=GenericConfigParser,
+        search_path=['output'],
+    )
+    parsed_object = parser.parse(config, output_dir)
+
+    if not isinstance(parsed_object, Aggregation):
+        raise YamlParseError(
+            config.context,
+            f'Invalid output configuration; expected an Aggregation, found: {type(parsed_object)}.',
+        )
+
+    return parsed_object
+
+
+def parse_aggregations(
+    config: ContextAwareList | ContextAwareDict | str, output_dir: Path, context: list[str] | None = None
+) -> list[Aggregation]:
+    """
+    Parse a list of configurations for aggregation.
+
+    :param config: the configuration section of a single aggregation, or a list of aggregation configurations
+    :param output_dir: the output directory for the aggregations
+    :param context: the context cof the configuration (if `config` is a `str`)
+    :return: a list of Aggregation objects
+    """
+    context = context or getattr(config, 'context', None) or []
+    if isinstance(config, list):
+        return [parse_aggregation(item, output_dir, context) for i, item in enumerate(config)]
+    else:
+        return [parse_aggregation(config, output_dir, context)]

--- a/lir/data/datasets/feature_data_csv.py
+++ b/lir/data/datasets/feature_data_csv.py
@@ -289,7 +289,7 @@ def _parse_cell_type(value: str) -> Callable[[str], Any]:
 def _parse_extra_field(config: ContextAwareDict) -> ExtraField:
     name = pop_field(config, 'name')
     columns = pop_field(config, 'columns', validate=partial(check_type, list))
-    cell_type = pop_field(config, 'cell_type', validate=_parse_cell_type)
+    cell_type = pop_field(config, 'cell_type', validate=_parse_cell_type, default=str)
     check_is_empty(config)
     return ExtraField(name, columns, cell_type)
 

--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -88,6 +88,7 @@ output:
   invariance_delta_function: lir.aggregation.plot_invariance_delta_function
   tippett: lir.aggregation.plot_tippett
   save_model: lir.persistence.parse_save_model
+  by_category: lir.config.aggregation.subset_aggregation
   
 pairing:
   instance_pairs: lir.transform.pairing.InstancePairing

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,8 +1,9 @@
+import numpy as np
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from lir import registry
-from lir.aggregation import Aggregation, AggregationData
+from lir.aggregation import Aggregation, AggregationData, SubsetAggregation
 from lir.config.base import GenericConfigParser, _expand
 from lir.data.models import LLRData
 from lir.lrsystems.binary_lrsystem import BinaryLRSystem
@@ -13,7 +14,14 @@ def test_registry_items_available(synthesized_llrs_with_interval: LLRData, tmp_p
     """Test all registered output aggregation methods."""
 
     # define a mapping from output aggregator to initialization arguments
-    args = {'output.csv': {'columns': []}}
+    args_by_method = {
+        'output.csv': {'columns': []},
+        'output.by_category': {'category_field': 'my_category_field', 'output': 'pav'},
+    }
+
+    synthesized_llrs_with_interval = synthesized_llrs_with_interval.replace(
+        my_category_field=np.array(['a'] * len(synthesized_llrs_with_interval))
+    )
 
     # iterate over all registry items
     for name in registry.registry():
@@ -21,7 +29,7 @@ def test_registry_items_available(synthesized_llrs_with_interval: LLRData, tmp_p
         if name.startswith('output.'):
             # create the object
             parser = registry.get(name, default_config_parser=GenericConfigParser)
-            args = _expand([], args.get(name, {}))
+            args = _expand([], args_by_method.get(name, {}))
             obj = parser.parse(args, tmp_path_factory.mktemp('output'))
             assert isinstance(obj, Aggregation), f'registry item is not an instance of `Aggregation`: {name}'
 
@@ -35,3 +43,18 @@ def test_registry_items_available(synthesized_llrs_with_interval: LLRData, tmp_p
                 )
             except Exception as _:
                 pytest.fail(f'generating output failed for registry item `{name}`')
+
+
+def test_subset_aggregation():
+    class MyAggregation(Aggregation):
+        def report(self, data: AggregationData) -> None:
+            assert len(data.llrdata) == len(llrs) / 2, 'number of LLRs within a category'
+            assert np.all(data.llrdata.llrs == data.llrdata.llrs[0]), (
+                'LLRs of the same category must have the same value'
+            )
+
+    llrs = LLRData(features=np.arange(2).repeat(10).reshape((20, 1)), category=np.arange(2).repeat(10))
+    aggregation = SubsetAggregation(aggregation_methods=[MyAggregation()], category_field='category')
+    aggregation.report(
+        AggregationData(run_name='testrun', llrdata=llrs, lrsystem=BinaryLRSystem(pipeline=Identity()), parameters={})
+    )


### PR DESCRIPTION
depends on #299 

closes #265 

Om te testen kan je data genereren uit de glass-data (duplo.csv):

```sh
cat duplo.csv | sed -e 1s/^/\"category\",/ -e '2,200 s/^/eersten,/' -e '201,300 s/^/tweeden,/' -e '301,$s/^/derden,/' >categorized.csv
```

De categorieen van de instances zijn dan:
- eersten
- tweeden
- derden

Daarna maak je een bijbehorende YAML:

```yaml
output_path: output/${timestamp}_score_based_common_source  # <-- adapt this value to your preference 

my_data_provider:
  method: parse_features_from_csv_file
  file: categorized.csv
  source_id_column: Item
  instance_id_column: id
  ignore_columns:
    - Piece
  extra_fields:
    - name: category
      columns: [category]

my_data_splits:
  strategy: multiclass_train_test_split
  test_size: .5

my_score_based_lr_system:
  architecture: score_based
  
  preprocessing:
  pairing:
    method: source_pairs
    ratio_limit: 2

  comparing:
    steps:
      scoring: element_wise_difference
      clf: logistic_regression
      to_llr: probabilities_to_logodds

experiments:                             
  - name: my_validation_run
    strategy: single_run
    lr_system: ${my_score_based_lr_system}
    data:
      provider: ${my_data_provider}
      splits: ${my_data_splits}
    output:
      - metrics
      - pav
      - method: by_category
        category_field: category
        output:
          - metrics
          - pav
```

Doordat paren gemaakt zijn, krijgt de subset-aggregatie de volgende categorieen te verwerken:
- eersten_eersten
- eersten_tweeden
- eersten_derden
- ... enzovoort ...

De meeste categorieen hebben geen same-source data, en daarom krijg je wat warnings op je scherm, maar de output klopt wel en wordt mooi in een apart mapje gestopt, dus geen conflicten met de top-level aggregaties.