### PR TITLE
Close every generated pyplot at the end, saved or not

### DIFF
--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -95,7 +95,8 @@ class AggregatePlot(Aggregation):
 
             LOG.info(f'Saving plot {self.plot_name} for run `{run_name}` to {file_name}')
             fig.savefig(file_name)
-            plt.close(fig)
+
+        plt.close(fig)
 
 
 @config_parser


### PR DESCRIPTION
Currently, we only close pyplot figures that are persisted on disk.

In other situations, we don't close the figure leading to a `RuntimeWarning` that there are retained pyplot figures which may consume memory. At the end of the function, we should always close the pyplot figure, if it has been saved or not.