### PR TITLE
Improve doc linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,26 +29,15 @@ pygments_style = 'sphinx'  # enable syntax highlighting
 # modindex_common_prefix = ['lir.']
 
 extensions = [
-    'autodoc2',
-    'myst_parser',
+    'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx_rtd_theme',
     'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'myst_parser',
+    'sphinx_rtd_theme',
     'sphinx_jinja',
     'jupyter_sphinx',
 ]
-
-autodoc2_packages = [
-    '../lir',
-]
-
-autodoc2_output_dir = 'api'
-
-autodoc2_docstring_parser_regexes = [
-    (r'.*', 'myst'),
-]
-
-myst_enable_extensions = ['fieldlist']
 
 templates_path = ['_templates']
 exclude_patterns = []
@@ -57,7 +46,6 @@ exclude_patterns = []
 autosummary_generate = True
 
 # Napoleon settings
-napoleon_google_docstring = True
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False

--- a/lir/__init__.py
+++ b/lir/__init__.py
@@ -13,9 +13,15 @@ from lir.transform import Transformer
 
 
 def is_interactive() -> bool:
-    """Determine if the LiR tool is running from the CLI and should be interactive.
+    """
+    Determine if the LiR tool is running from the CLI and should be interactive.
 
     This method is used, for example, to determine if a progress bar should be shown.
+
+    Returns
+    -------
+    bool
+        `True` when standard output is connected to a terminal, otherwise `False`.
     """
     return sys.stdout.isatty()
 

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -26,14 +26,21 @@ LOG = logging.getLogger(__name__)
 
 
 class AggregationData(NamedTuple):
-    """Representation of aggregated data.
+    """
+    Representation of aggregated data.
 
-    Fields:
-    - llrdata: the LLR data containing LLRs and labels.
-    - lrsystem: the model that produced the results
-    - get_full_fit_lrsystem: optional callable that lazily provides a model fitted on full data (ignoring splits)
-    - parameters: parameters that identify the system producing the results
-    - run_name: string representation of the run that produced the results
+    Attributes
+    ----------
+    llrdata : LLRData
+        The LLR data containing LLRs and labels.
+    lrsystem : LRSystem
+        The model that produced the results.
+    parameters : dict[str, Any]
+        Parameters that identify the system producing the results.
+    run_name : str
+        String representation of the run that produced the results.
+    get_full_fit_lrsystem : Callable[[], LRSystem] | None
+        Optional callable that lazily provides a model fitted on full data (ignoring splits).
     """
 
     llrdata: LLRData
@@ -44,7 +51,8 @@ class AggregationData(NamedTuple):
 
 
 class Aggregation(ABC):
-    """Base representation of an aggregated data collection.
+    """
+    Base representation of an aggregated data collection.
 
     Other classes may extend from this class.
     """
@@ -54,7 +62,10 @@ class Aggregation(ABC):
         """
         Report that new results are available.
 
-        :param data: a named tuple containing the results
+        Parameters
+        ----------
+        data : AggregationData
+            The aggregated data to be reported.
         """
         raise NotImplementedError
 
@@ -78,16 +89,61 @@ class Aggregation(ABC):
 
 
 class AggregatePlot(Aggregation):
-    """Aggregation that generates plots by repeatedly calling a plotting function."""
+    """
+    Aggregation that generates plots by repeatedly calling a plotting function.
 
-    def __init__(self, plot_fn: Callable, plot_name: str, output_dir: Path | None = None, **kwargs: Any) -> None:
-        self.output_path = output_dir
+    Parameters
+    ----------
+    plot_fn : Callable
+        The plotting function to be used for generating plots.
+    plot_name : str
+        The name of the plot.
+    output_path : Path | None, optional
+        The directory where the plots will be saved. If `None`, plots are not saved.
+    **kwargs : Any
+        Additional arguments to be passed to the plotting function.
+
+    Attributes
+    ----------
+    output_path : Path | None
+        The directory where the plots will be saved. If `None`, plots are not saved.
+    plot_fn : Callable
+        The plotting function to be used for generating plots.
+    plot_name : str
+        The name of the plot.
+    plot_fn_args : dict[str, Any]
+        Additional arguments to be passed to the plotting function.
+    """
+
+    def __init__(self, plot_fn: Callable, plot_name: str, output_path: Path | None = None, **kwargs: Any) -> None:
+        """
+        Initialize the AggregatePlot.
+
+        Parameters
+        ----------
+        plot_fn : Callable
+            The plotting function to be used for generating plots.
+        plot_name : str
+            The name of the plot.
+        output_path : Path | None, optional
+            The directory where the plots will be saved. If `None`, plots are not saved.
+        **kwargs : Any
+            Additional arguments to be passed to the plotting function.
+        """
+        self.output_path = output_path
         self.plot_fn = plot_fn
         self.plot_name = plot_name
         self.plot_fn_args = kwargs
 
     def report(self, data: AggregationData) -> None:
-        """Plot the data when new results are available."""
+        """
+        Plot the data when new results are available.
+
+        Parameters
+        ----------
+        data : AggregationData
+            The aggregated data to be plotted.
+        """
         fig, ax = plt.subplots()
 
         llrdata = data.llrdata
@@ -115,69 +171,194 @@ class AggregatePlot(Aggregation):
 
 @config_parser(reference=pav)
 def plot_pav(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate PAV plot."""
+    """
+    Corresponding registry function to generate aggregate PAV plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate PAV plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='PAV')
     return AggregatePlot(pav, plot_name, output_dir, **config)
 
 
 @config_parser(reference=ece)
 def plot_ece(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate ECE plot."""
+    """
+    Corresponding registry function to generate aggregate ECE plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate ECE plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='ECE')
     return AggregatePlot(ece, plot_name, output_dir, **config)
 
 
 @config_parser(reference=lr_histogram)
 def plot_lr_histogram(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate LR Histogram."""
+    """
+    Corresponding registry function to generate aggregate LR Histogram.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate LR Histogram plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='LR_Histogram')
     return AggregatePlot(lr_histogram, plot_name, output_dir, **config)
 
 
 @config_parser(reference=llr_interval)
 def plot_llr_interval(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate LLR interval plot."""
+    """
+    Corresponding registry function to generate aggregate LLR interval plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate LLR interval plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='LLR_Interval')
     return AggregatePlot(llr_interval, plot_name, output_dir, **config)
 
 
 @config_parser(reference=llr_overestimation)
 def plot_llr_overestimation(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate LLR overestimation plot."""
+    """
+    Corresponding registry function to generate aggregate LLR overestimation plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate LLR overestimation plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='LLR_Overestimation')
     return AggregatePlot(llr_overestimation, plot_name, output_dir, **config)
 
 
 @config_parser(reference=nbe)
 def plot_nbe(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate NBE plot."""
+    """
+    Corresponding registry function to generate aggregate NBE plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate NBE plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='NBE')
     return AggregatePlot(nbe, plot_name, output_dir, **config)
 
 
 @config_parser(reference=tippett)
 def plot_tippett(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate Tippett plot."""
+    """
+    Corresponding registry function to generate aggregate Tippett plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate Tippett plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='Tippett')
     return AggregatePlot(tippett, plot_name, output_dir, **config)
 
 
 @config_parser(reference=invariance_delta_functions)
 def plot_invariance_delta_function(config: ContextAwareDict, output_dir: Path) -> AggregatePlot:
-    """Corresponding registry function to generate aggregate invariance delta function plot."""
+    """
+    Corresponding registry function to generate aggregate invariance delta function plot.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the plot.
+    output_dir : Path
+        The directory where the plot will be saved.
+
+    Returns
+    -------
+    AggregatePlot
+        An instance of the AggregatePlot class configured to generate invariance delta function plots.
+    """
     plot_name = pop_field(config, 'plot_name', default='Invariance_Delta_Functions')
     return AggregatePlot(invariance_delta_functions, plot_name, output_dir, **config)
 
 
 class WriteMetricsToCsv(Aggregation):
-    """Helper class to write aggregated results to CSV file."""
+    """
+    Helper class to write aggregated results to CSV file.
+
+    Parameters
+    ----------
+    path : Path
+        The path to the CSV file where the metrics will be written.
+    columns : Mapping[str, Callable]
+        A mapping of column names to metric functions that compute the values for those columns.
+    """
 
     def __init__(self, path: Path, columns: Mapping[str, Callable]):
         """
         Initialize the class.
 
-        :param path: the path to the CSV file
-        :param columns: the columns as a dictionary of names to metric functions
+        Parameters
+        ----------
+        path : Path
+            The path to the CSV file where the metrics will be written.
+        columns : Mapping[str, Callable]
+            A mapping of column names to metric functions that compute the values for those columns.
         """
         self.path = path
         self._file: IO[Any] | None = None
@@ -193,7 +374,14 @@ class WriteMetricsToCsv(Aggregation):
             return ''
 
     def report(self, data: AggregationData) -> None:
-        """Write the metrics to CSV."""
+        """
+        Write the metrics to CSV.
+
+        Parameters
+        ----------
+        data : AggregationData
+            The aggregated data for which to compute and write the metrics.
+        """
         columns = [
             (key, self._safe_call(partial(metric, data.llrdata), f'calculating metric {key} failed'))
             for key, metric in self.columns.items()
@@ -225,7 +413,21 @@ class WriteMetricsToCsv(Aggregation):
 
 @config_parser
 def metrics_csv(config: ContextAwareDict, output_dir: Path) -> WriteMetricsToCsv:
-    """Corresponding registry function to leverage CSV Writer class to write results to disk."""
+    """
+    Corresponding registry function to leverage CSV Writer class to write results to disk.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration dictionary for the metrics CSV.
+    output_dir : Path
+        The directory where the metrics CSV will be saved.
+
+    Returns
+    -------
+    WriteMetricsToCsv
+        An instance of the WriteMetricsToCsv class configured to write metrics to a CSV file.
+    """
     columns = pop_field(config, 'columns', default=['cllr', 'cllr_min'])
     if not isinstance(columns, Sequence):
         raise YamlParseError(
@@ -306,14 +508,25 @@ class SubsetAggregation(Aggregation):
     Aggregation method that manages data categorization.
 
     A separate aggregation method is used for each category.
+
+    Parameters
+    ----------
+    aggregation_methods : list[Aggregation]
+        A list of methods to aggregate results by category.
+    category_field : str
+        The name of the category field.
     """
 
     def __init__(self, aggregation_methods: list[Aggregation], category_field: str):
         """
         Initialize the subset aggregation method.
 
-        :param aggregation_methods: a list of methods to aggregate results by category
-        :param category_field: the name of the category field
+        Parameters
+        ----------
+        aggregation_methods : list[Aggregation]
+            A list of methods to aggregate results by category.
+        category_field : str
+            The name of the category field.
         """
         self.aggregation_methods = aggregation_methods
         self.category_field = category_field
@@ -324,7 +537,10 @@ class SubsetAggregation(Aggregation):
 
         The data are categorized into subsets and forwarded to the actual aggregation method.
 
-        :param data: a named tuple containing the results
+        Parameters
+        ----------
+        data : AggregationData
+            The aggregated data to be reported.
         """
         run_name_prefix = f'{data.run_name}/' if data.run_name else ''
         for category, subset in get_instances_by_category(data.llrdata, self.category_field):

--- a/lir/aggregation.py
+++ b/lir/aggregation.py
@@ -442,7 +442,18 @@ def metrics_csv(config: ContextAwareDict, output_dir: Path) -> WriteMetricsToCsv
 
 
 class CaseLLRToCsv(Aggregation):
-    """Aggregation that applies a full-data-fitted LR system to case data and stores LLRs as CSV."""
+    """
+    Aggregation that applies a full-data-fitted LR system to case data and stores LLRs as CSV.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory where the CSV file will be written.
+    case_data_provider : DataProvider
+        Provider for the case data to apply the LR system to.
+    filename : str, optional
+        Name of the output CSV file, by default 'case_llr.csv'.
+    """
 
     def __init__(self, output_dir: Path, case_data_provider: DataProvider, filename: str = 'case_llr.csv') -> None:
         self.output_dir = output_dir
@@ -450,7 +461,14 @@ class CaseLLRToCsv(Aggregation):
         self.filename = Path(filename)
 
     def report(self, data: AggregationData) -> None:
-        """Apply the full-data-fitted LR system to the case data and store the resulting LLRs as CSV."""
+        """
+        Apply the full-data-fitted LR system to the case data and store the resulting LLRs as CSV.
+
+        Parameters
+        ----------
+        data : AggregationData
+            Aggregation data containing the fitted LR system and case data.
+        """
         if data.get_full_fit_lrsystem is not None:
             lrsystem = data.get_full_fit_lrsystem()
         else:
@@ -495,7 +513,21 @@ class CaseLLRToCsv(Aggregation):
 
 @config_parser
 def case_llr_csv(config: ContextAwareDict, output_dir: Path) -> CaseLLRToCsv:
-    """Parse output configuration for case LLR generation and CSV export."""
+    """
+    Parse output configuration for case LLR generation and CSV export.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration dictionary containing case LLR output settings.
+    output_dir : Path
+        Directory where the CSV file will be written.
+
+    Returns
+    -------
+    CaseLLRToCsv
+        Configured CaseLLRToCsv aggregation instance.
+    """
     case_data_provider = parse_data_provider(pop_field(config, 'case_llr_data'), output_dir)
     filename = pop_field(config, 'filename', default='case_llr.csv', validate=str)
     filename = check_type(str, filename)

--- a/lir/algorithms/bayeserror.py
+++ b/lir/algorithms/bayeserror.py
@@ -24,13 +24,22 @@ def plot_nbe(
     add_misleading: int = 1,
     step_size: float = 0.01,
 ) -> None:
-    """Generate the visual NBE plot using matplotlib.
+    """
+    Generate the visual NBE plot using matplotlib.
 
-    :param ax: the matplotlib axis to plot on
-    :param llrdata: the LLR data containing LLRs and labels
-    :param log_lr_threshold_range: the range of log LR threshold values
-    :param add_misleading: number of misleading evidence points to add
-    :param step_size: step size for the log LR threshold range
+    Parameters
+    ----------
+    ax : plt.Axes
+        The matplotlib axis to plot on.
+    llrdata : LLRData
+        An instance of LLRData containing LLRs and ground-truth labels.
+    log_lr_threshold_range : tuple[float, float] | None, optional
+        The range of log LR threshold values to consider for the plot. If None, it will be determined based on the
+        minimum and maximum LLRs in the data, with a margin of 0.5 added to both ends. Default is None.
+    add_misleading : int, optional
+        The number of consequential misleading LLRs to be added to both sides (labels 0 and 1). Default is 1.
+    step_size : float, optional
+        The step size for the log LR threshold range, determining the resolution of the plot. Default is 0.01.
     """
     llrs = llrdata.llrs
     y = llrdata.labels
@@ -60,14 +69,24 @@ def elub(
     step_size: float = 0.01,
     substitute_extremes: tuple[float, float] = (-9, 9),
 ) -> tuple[float, float]:
-    """Calculate and return the empirical upper and lower bound log10-LRs (ELUB LLRs).
+    """
+    Calculate and return the empirical upper and lower bound log10-LRs (ELUB LLRs).
 
-    :param llrdata: An instance of LLRData containing LLRs and ground-truth labels
-    :param add_misleading: the number of consequential misleading LLRs to be added
-        to both sides (labels 0 and 1)
-    :param step_size: required accuracy on a 10-base logarithmic scale
-    :param substitute_extremes: tuple of scalars: substitute for extreme LRs, i.e.
-        LRs of 0 and inf are substituted by these values
+    Parameters
+    ----------
+    llrdata : LLRData
+        An instance of LLRData containing LLRs and ground-truth labels.
+    add_misleading : int, optional
+        The number of consequential misleading LLRs to be added to both sides (labels 0 and 1).
+    step_size : float, optional
+        Required accuracy on a 10-base logarithmic scale.
+    substitute_extremes : tuple[float, float], optional
+        The values to substitute for extreme LRs, i.e. LRs of 0 and inf are substituted by these values.
+
+    Returns
+    -------
+    tuple[float, float]
+        A tuple containing the lower and upper ELUB log10-LRs.
     """
     llrs = llrdata.llrs
     y = llrdata.labels
@@ -109,14 +128,24 @@ def elub(
 def calculate_expected_utility(
     lrs: np.ndarray, y: np.ndarray, threshold_lrs: np.ndarray, add_misleading: int = 0
 ) -> float:
-    """Calculate the expected utility of a set of LRs for a given threshold.
+    """
+    Calculate the expected utility of a set of LRs for a given threshold.
 
-    :param lrs: an array of LRs
-    :param y: an array of ground-truth labels (values 0 for Hd or 1 for Hp);
-        must be of the same length as `lrs`
-    :param threshold_lrs: an array of threshold lrs: minimum LR for acceptance
-    :param add_misleading: the number of consequential misleading LRs to be added.
-    :returns: an array of utility values, one element for each threshold LR
+    Parameters
+    ----------
+    lrs : np.ndarray
+        Array of LRs.
+    y : np.ndarray
+        Array of ground-truth labels (0 for Hd or 1 for Hp), with the same length as `lrs`.
+    threshold_lrs : np.ndarray
+        Array of threshold LRs used as acceptance thresholds.
+    add_misleading : int, optional
+        Number of consequential misleading LRs to add.
+
+    Returns
+    -------
+    float
+        Expected utility values, one element for each threshold LR.
     """
     m_accept = lrs.reshape(len(lrs), 1) > threshold_lrs.reshape(1, len(threshold_lrs))
 
@@ -136,7 +165,8 @@ def calculate_expected_utility(
 
 
 class ELUBBounder(LLRBounder):
-    """Calculate the Empirical Upper and Lower Bounds for a given LR system.
+    """
+    Calculate the Empirical Upper and Lower Bounds for a given LR system.
 
     Class that, given an LR system, outputs the same LRs as the system but bounded by the Empirical Upper and Lower
     Bounds as described in
@@ -171,5 +201,17 @@ class ELUBBounder(LLRBounder):
     """
 
     def calculate_bounds(self, llrdata: LLRData) -> tuple[float | None, float | None]:
-        """Calculate the LLR empirical upper and lower bounds (ELUB)."""
+        """
+        Calculate the LLR empirical upper and lower bounds (ELUB).
+
+        Parameters
+        ----------
+        llrdata : LLRData
+            An instance of LLRData containing LLRs and ground-truth labels.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            A tuple containing the lower and upper bounds. If the bounds cannot be calculated, returns (None, None).
+        """
         return elub(llrdata, add_misleading=1)

--- a/lir/algorithms/bootstraps.py
+++ b/lir/algorithms/bootstraps.py
@@ -15,7 +15,8 @@ from lir.util import check_type
 
 
 class Bootstrap(Pipeline, ABC):
-    """Bootstrap system that estimates confidence intervals around the best estimate of a pipeline.
+    """
+    Bootstrap system that estimates confidence intervals around the best estimate of a pipeline.
 
     This bootstrap system creates bootstrap samples from the training data, fits the pipeline on each sample,
     and then computes confidence intervals for the pipeline outputs based on the variability across the bootstrap
@@ -30,6 +31,17 @@ class Bootstrap(Pipeline, ABC):
 
     The AtData variant allows for more complex data types, while the Equidistant variant is only suitable for continuous
     features.
+
+    Parameters
+    ----------
+    steps : list[tuple[str, Any]]
+        The pipeline steps to bootstrap.
+    n_bootstraps : int, optional
+        Number of bootstrap samples to generate.
+    interval : tuple[float, float], optional
+        Lower and upper quantiles for the confidence interval.
+    seed : int | None, optional
+        Random seed for reproducibility.
     """
 
     def __init__(
@@ -39,13 +51,19 @@ class Bootstrap(Pipeline, ABC):
         interval: tuple[float, float] = (0.05, 0.95),
         seed: int | None = None,
     ):
-        """Initialize the TrainDataBootstrap with the given pipeline steps, number of bootstraps, and interval.
+        """
+        Initialize the bootstrap instance.
 
-        :param steps: list[tuple[str, Any]]: The steps of the pipeline to be bootstrapped.
-        :param n_bootstraps: int: The number of bootstrap samples to generate. Default is 400.
-        :param interval: tuple[float, float]: The lower and upper quantiles for the confidence interval.
-                                             Default: (0.05,0.95).
-        :param seed: int | None: The random seed for reproducibility. Default is None.
+        Parameters
+        ----------
+        steps : list[tuple[str, Any]]
+            The pipeline steps to bootstrap.
+        n_bootstraps : int, optional
+            Number of bootstrap samples to generate.
+        interval : tuple[float, float], optional
+            Lower and upper quantiles for the confidence interval.
+        seed : int | None, optional
+            Random seed for reproducibility.
         """
         super().__init__(steps)
 
@@ -58,18 +76,37 @@ class Bootstrap(Pipeline, ABC):
 
     @abstractmethod
     def get_bootstrap_data(self, instances: InstanceData) -> InstanceData:
-        """Get the data points to use for interval estimation.
+        """
+        Get the data points to use for interval estimation.
 
-        :param instances: FeatureData: The feature data to fit the bootstrap system on.
-        :return FeatureData: The feature data to use for interval estimation.
+        This method should be implemented by subclasses to specify how the data points for interval estimation are
+        obtained.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to fit the bootstrap system on.
+
+        Returns
+        -------
+        InstanceData
+            The feature data to use for interval estimation.
         """
         raise NotImplementedError
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Transform the provided instances to include the best estimate and confidence intervals.
+        """
+        Transform the provided instances to include the best estimate and confidence intervals.
 
-        :param instances: FeatureData: The feature data to transform.
-        :return LLRData: The transformed feature data with best estimate and confidence intervals.
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to transform.
+
+        Returns
+        -------
+        LLRData
+            The transformed feature data with best estimate and confidence intervals.
         """
         if self.f_delta_interval_lower is None or self.f_delta_interval_upper is None:
             raise ValueError('Bootstrap intervals have not been computed. Please fit the bootstrap first.')
@@ -85,18 +122,34 @@ class Bootstrap(Pipeline, ABC):
         )
 
     def fit_apply(self, instances: InstanceData) -> LLRData:
-        """Combine fitting and transforming in one step.
+        """
+        Combine fitting and transforming in one step.
 
-        :param instances: FeatureData: The feature data to fit and transform.
-        :return LLRData: The transformed feature data with best estimate and confidence intervals.
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to fit and transform.
+
+        Returns
+        -------
+        LLRData
+            The transformed feature data with best estimate and confidence intervals.
         """
         return self.fit(instances).apply(instances)
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the bootstrap system to the provided instances.
+        """
+        Fit the bootstrap system to the provided instances.
 
-        :param instances: FeatureData: The feature data to fit the bootstrap system on.
-        :return Self: The fitted bootstrap system.
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to fit the bootstrap system on.
+
+        Returns
+        -------
+        Self
+            The fitted bootstrap system.
         """
         all_vals = []
         rng = np.random.default_rng(self.seed)
@@ -138,24 +191,49 @@ class Bootstrap(Pipeline, ABC):
 
 
 class BootstrapAtData(Bootstrap):
-    """Bootstrap system that uses the original training data points for interval estimation.
+    """
+    Bootstrap system that uses the original training data points for interval estimation.
 
     See the Bootstrap class for more details.
     """
 
     def get_bootstrap_data(self, instances: InstanceData) -> InstanceData:
-        """Get the data points to use for interval estimation. The original training data points are used.
+        """
+        Get the data points to use for interval estimation.
 
-        :param instances: FeatureData: The feature data to fit the bootstrap system on.
-        :return FeatureData: The feature data to use for interval estimation.
+        The original training data points are used.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to fit the bootstrap system on.
+
+        Returns
+        -------
+        InstanceData
+            The feature data to use for interval estimation.
         """
         return instances
 
 
 class BootstrapEquidistant(Bootstrap):
-    """Bootstrap system that uses equidistant points within the range of the training data for interval estimation.
+    """
+    Bootstrap system that uses equidistant points within the range of the training data for interval estimation.
 
     See the Bootstrap class for more details.
+
+    Parameters
+    ----------
+    steps : list[tuple[str, Any]]
+        The pipeline steps to bootstrap.
+    n_bootstraps : int, optional
+        Number of bootstrap samples to generate.
+    interval : tuple[float, float], optional
+        Lower and upper quantiles for the confidence interval.
+    seed : int | None, optional
+        Random seed for reproducibility.
+    n_points : int | None, optional
+        Number of equidistant points to use for interval estimation.
     """
 
     def __init__(
@@ -166,26 +244,42 @@ class BootstrapEquidistant(Bootstrap):
         seed: int | None = None,
         n_points: int | None = 1000,
     ):
-        """Initialize the instance with the given pipeline steps, number of bootstraps, and interval.
+        """
+        Initialize the instance with the given pipeline steps, number of bootstraps, and interval.
 
-        :param steps: list[tuple[str, Any]]: The steps of the pipeline to be bootstrapped.
-        :param n_bootstraps: int: The number of bootstrap samples to generate. Default is 400.
-        :param interval: tuple[float, float]: The lower and upper quantiles for the confidence interval.
-                                             Default: (0.05,0.95).
-        :param seed: int | None: The random seed for reproducibility. Default is None.
-        :param n_points: int | None: The number of equidistant points to use for interval estimation. Default is 1000.
-                                    If None, uses the number of instances in the training data.
+        Parameters
+        ----------
+        steps : list[tuple[str, Any]]
+            The steps of the pipeline to be bootstrapped.
+        n_bootstraps : int, optional
+            The number of bootstrap samples to generate. Default is 400.
+        interval : tuple[float, float], optional
+            The lower and upper quantiles for the confidence interval. Default: (0.05,0.95).
+        seed : int | None, optional
+            The random seed for reproducibility. Default is None.
+        n_points : int | None, optional
+            The number of equidistant points to use for interval estimation. Default is 1000. If None, uses the number
+            of instances in the training data.
         """
         super().__init__(steps, n_bootstraps, interval, seed)
         self.n_points = n_points
 
     def get_bootstrap_data(self, instances: InstanceData) -> FeatureData:
-        """Get the data points to use for interval estimation.
+        """
+        Get the data points to use for interval estimation.
 
         This is done by creating equidistant points within the range of the training data.
 
-        :param instances: FeatureData: The feature data to fit the bootstrap system on.
-        :return FeatureData: The feature data to use for interval estimation.
+        Parameters
+        ----------
+        instances : InstanceData
+            The feature data to fit the bootstrap system on.
+
+        Returns
+        -------
+        FeatureData
+            The feature data to use for interval estimation, consisting of equidistant points within the range of the
+            training data.
         """
         instances = check_type(FeatureData, instances)
         if instances.features.ndim != 2 or instances.features.shape[1] != 1:
@@ -215,9 +309,17 @@ def bootstrap(modules_config: ContextAwareDict, output_dir: Path) -> Bootstrap:
 
     Any other arguments are passed directly to the `__init__()` method of the bootstrapping class.
 
-    :param modules_config: the configuration
-    :param output_dir: where to write output, if any
-    :return: a bootstrapping object
+    Parameters
+    ----------
+    modules_config : ContextAwareDict
+        Bootstrap module configuration.
+    output_dir : Path
+        Output directory used for parsing nested pipeline steps.
+
+    Returns
+    -------
+    Bootstrap
+        A configured bootstrapping object.
     """
     bootstrap_methods = {
         'data': BootstrapAtData,

--- a/lir/algorithms/invariance_bounds.py
+++ b/lir/algorithms/invariance_bounds.py
@@ -21,12 +21,19 @@ def plot_invariance_delta_functions(
     step_size: float = 0.001,
     ax: plt.Axes | None = None,
 ) -> None:
-    """Return a figure of the Invariance Verification delta functions along with the upper and lower bounds of the LRs.
+    """
+    Plot Invariance Verification delta functions and LR bounds.
 
-    :param llrdata: An instance of LLRData containing LLRs and ground-truth labels
-    :param llr_threshold_range: lower limit and upper limit for the LLRs to include in the figure
-    :param step_size: required accuracy on a base-10 logarithmic scale
-    :param ax: matplotlib axes
+    Parameters
+    ----------
+    llrdata : LLRData
+        LLR data containing LLRs and ground-truth labels.
+    llr_threshold_range : tuple[float, float] | None, optional
+        Lower and upper limits for LLR thresholds to include in the figure.
+    step_size : float, optional
+        Required accuracy on a base-10 logarithmic scale.
+    ax : plt.Axes | None, optional
+        Matplotlib axes to plot into.
     """
     llrs, y = llrdata.llrs, llrdata.labels
     if y is None:
@@ -70,13 +77,24 @@ def calculate_invariance_bounds(
     step_size: float = 0.001,
     substitute_extremes: tuple[float, float] = (-20, 20),
 ) -> tuple[float, float, np.ndarray, np.ndarray]:
-    """Return the upper and lower Invariance Verification bounds of the LRs.
+    """
+    Return the upper and lower Invariance Verification bounds of the LRs.
 
-    :param llrdata: an instance of LLRData containing LLRs and ground-truth labels
-    :param llr_threshold: predefined values of LLRs as possible bounds
-    :param step_size: required accuracy on a base-10 logarithmic scale
-    :param substitute_extremes: (tuple of scalars) substitute for extreme LLRs, i.e.
-        LLRs smaller than the lower value or greater than the upper value are clipped
+    Parameters
+    ----------
+    llrdata : LLRData
+        LLR data containing LLRs and ground-truth labels.
+    llr_threshold : np.ndarray | None, optional
+        Predefined LLR thresholds as candidate bounds.
+    step_size : float, optional
+        Required accuracy on a base-10 logarithmic scale.
+    substitute_extremes : tuple[float, float], optional
+        Substitute values for extreme LLRs; smaller and larger LLRs are clipped.
+
+    Returns
+    -------
+    tuple[float, float, np.ndarray, np.ndarray]
+        Lower bound, upper bound, lower delta function values, and upper delta function values.
     """
     llrs, y = llrdata.llrs, llrdata.labels
 
@@ -118,11 +136,20 @@ def calculate_invariance_bounds(
 
 
 def calculate_invariance_delta_functions(llrdata: LLRData, llr_threshold: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Calculate the Invariance Verification delta functions for a set of LRs at given threshold values.
+    """
+    Calculate Invariance Verification delta functions for LRs at given thresholds.
 
-    :param llrdata: An instance of LLRData containing LLRs and ground-truth labels
-    :param llr_threshold: an array of threshold LLRs
-    :returns: two arrays of delta-values, at all threshold LR values
+    Parameters
+    ----------
+    llrdata : LLRData
+        LLR data containing LLRs and ground-truth labels.
+    llr_threshold : np.ndarray
+        Threshold LLR values.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Lower and upper delta values evaluated for all thresholds.
     """
     llrs, y = llrdata.llrs, llrdata.labels
     # fix the value used for the beta distributions at 1/2 (Jeffreys prior)
@@ -150,7 +177,8 @@ def calculate_invariance_delta_functions(llrdata: LLRData, llr_threshold: np.nda
 
 
 class IVBounder(LLRBounder):
-    """Calculate Invariance Verification bounds for a given LR system.
+    """
+    Calculate Invariance Verification bounds for a given LR system.
 
     Class that, given an LR system, outputs the same LRs as the system but bounded by the Invariance Verification
     bounds as described in:
@@ -160,6 +188,18 @@ class IVBounder(LLRBounder):
     """
 
     def calculate_bounds(self, llrdata: LLRData) -> tuple[float | None, float | None]:
-        """Calculate the Invariance Verification bounds."""
+        """
+        Calculate the Invariance Verification bounds.
+
+        Parameters
+        ----------
+        llrdata : LLRData
+            LLR data used to derive invariance bounds.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            Lower and upper LLR bounds.
+        """
         lower_llr_bound, upper_llr_bound = calculate_invariance_bounds(llrdata)[:2]
         return lower_llr_bound, upper_llr_bound

--- a/lir/algorithms/isotonic_regression.py
+++ b/lir/algorithms/isotonic_regression.py
@@ -11,7 +11,8 @@ from lir.util import check_type, probability_to_logodds
 
 
 class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
-    """Wrap SKlearn implementation to support infinite values.
+    """
+    Wrap SKlearn implementation to support infinite values.
 
     Sklearn implementation IsotonicRegression throws an error when values are Inf or -Inf when in fact
     IsotonicRegression can handle infinite values. This wrapper around the sklearn implementation of IsotonicRegression
@@ -19,20 +20,25 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
     """
 
     def fit(self, X: ArrayLike, y: ArrayLike, sample_weight: ArrayLike | tuple | None = None) -> 'IsotonicRegression':
-        """Fit the model using X, y as training data.
+        """
+        Fit the model using X, y as training data.
 
         X is stored for future use, as :meth:`transform` needs X to interpolate
         new input data.
 
-        :param X: array-like of shape (n_samples,)
-            Training data.
-        :param y: array-like of shape (n_samples,)
-            Training target.
-        :param sample_weight: array-like of shape (n_samples,), default=None
-            Weights. If set to None, all weights will be set to 1 (equal
-            weights).
+        Parameters
+        ----------
+        X : ArrayLike
+            Training data with shape ``(n_samples,)``.
+        y : ArrayLike
+            Training target with shape ``(n_samples,)``.
+        sample_weight : ArrayLike | tuple | None, optional
+            Sample weights. If `None`, equal weights are used.
 
-        :return: Returns an instance of self.
+        Returns
+        -------
+        IsotonicRegression
+            Fitted estimator.
         """
         check_params = dict(accept_sparse=False, ensure_2d=False, ensure_all_finite=False)  # noqa: C408
         X = check_array(X, dtype=[np.float64, np.float32], **check_params)
@@ -64,12 +70,18 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
         return self
 
     def transform(self, T: ArrayLike) -> np.ndarray:
-        """Transform new data by linear interpolation.
+        """
+        Transform new data by linear interpolation.
 
-        :param T: array-like of shape (n_samples,)
+        Parameters
+        ----------
+        T : ArrayLike
             Data to transform.
-        :return: array, shape=(n_samples,)
-            The transformed data
+
+        Returns
+        -------
+        np.ndarray
+            The transformed data.
         """
         dtype = self._necessary_X_.dtype if hasattr(self, '_necessary_X_') else np.float64
 
@@ -104,7 +116,8 @@ class IsotonicRegression(sklearn.isotonic.IsotonicRegression):
 
 
 class IsotonicCalibrator(Transformer):
-    """Calculate LR from a score belonging to one of two distributions using isotonic regression.
+    """
+    Calculate LR from a score belonging to one of two distributions using isotonic regression.
 
     Calculates a likelihood ratio of a score value, provided it is from one of
     two distributions. Uses isotonic regression for interpolation.
@@ -113,15 +126,39 @@ class IsotonicCalibrator(Transformer):
 
     - has an initialization argument that provides the option of adding misleading data points
     - outputs logodds instead of probabilities
+
+    Parameters
+    ----------
+    add_misleading : int, optional
+        Number of synthetic misleading points to add to reduce extreme LRs.
     """
 
     def __init__(self, add_misleading: int = 0):
-        """:param add_misleading:"""
+        """
+        Initialize an isotonic calibrator.
+
+        Parameters
+        ----------
+        add_misleading : int, optional
+            Number of synthetic misleading points to add to reduce extreme LRs.
+        """
         self.add_misleading = add_misleading
         self._ir = IsotonicRegression(out_of_bounds='clip')
 
     def fit(self, instances: InstanceData) -> Self:
-        """Allow fitting the estimator on the given data."""
+        """
+        Fit the estimator on the given data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            Fitted calibrator.
+        """
         y = instances.check_both_labels()
         instances = check_type(FeatureData, instances).replace_as(LLRData)
 
@@ -144,11 +181,35 @@ class IsotonicCalibrator(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Transform a given value, using the fitted Isotonic Regression model."""
+        """
+        Transform instances using the fitted isotonic regression model.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to transform.
+
+        Returns
+        -------
+        LLRData
+            Calibrated log-likelihood-ratio data.
+        """
         instances = check_type(FeatureData, instances).replace_as(LLRData)
         probs = self._ir.transform(instances.llrs)
         return instances.replace_as(LLRData, features=probability_to_logodds(probs).reshape(-1, 1))
 
     def fit_apply(self, instances: InstanceData) -> LLRData:
-        """Fit and apply the calibrator to the given data."""
+        """
+        Fit and apply the calibrator to the given data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to fit and transform.
+
+        Returns
+        -------
+        LLRData
+            Calibrated log-likelihood-ratio data.
+        """
         return self.fit(instances).apply(instances)

--- a/lir/algorithms/kde.py
+++ b/lir/algorithms/kde.py
@@ -19,13 +19,20 @@ LOG = logging.getLogger(__name__)
 def compensate_and_remove_neginf_inf(
     log_odds: np.ndarray, y: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray, float, float]:
-    """For Gaussian and KDE-calibrator fitting: remove negInf, Inf and compensate.
+    """
+    Remove infinite log-odds values and compute compensation factors.
 
-    :param log_odds: n * 1 np.array of log-odds
-    :param y: n * 1 np.array of labels (Booleans).
+    Parameters
+    ----------
+    log_odds : np.ndarray
+        Array of log-odds.
+    y : np.ndarray
+        Array of labels.
 
-    :returns: log_odds (with negInf and Inf removed), y (with negInf and Inf removed),
-                numerator compensator, denominator compensator
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, float, float]
+        Finite log-odds, corresponding labels, numerator compensator, and denominator compensator.
     """
     X_finite = np.isfinite(log_odds).flatten()
     el_H1 = np.logical_and(X_finite, y == 1)
@@ -39,20 +46,46 @@ def compensate_and_remove_neginf_inf(
 
 
 def _fixed_bandwidth(X: Any, y: Any, *, bandwidth_0: float, bandwidth_1: float) -> tuple[float, float]:
-    """Return a fixed bandwidth pair. Module-level so it is picklable."""
+    """
+    Return a fixed bandwidth pair.
+
+    Parameters
+    ----------
+    X : Any
+        Unused input data placeholder.
+    y : Any
+        Unused input labels placeholder.
+    bandwidth_0 : float
+        Bandwidth for class 0.
+    bandwidth_1 : float
+        Bandwidth for class 1.
+
+    Returns
+    -------
+    tuple[float, float]
+        Fixed bandwidths for class 0 and class 1.
+    """
     return (bandwidth_0, bandwidth_1)
 
 
 def parse_bandwidth(
     bandwidth: Callable | str | float | tuple[float, float] | None,
 ) -> Callable[[Any, Any], tuple[float, float]]:
-    """Parse and return the corresponding bandwidth based on input type.
+    """
+    Parse and return the corresponding bandwidth strategy based on input type.
 
     Returns bandwidth as a tuple of two (optional) floats.
     Extrapolates a single bandwidth.
 
-    :param bandwidth: provided bandwidth
-    :return: bandwidth used for kde0, bandwidth used for kde1
+    Parameters
+    ----------
+    bandwidth : Callable | str | float | tuple[float, float] | None
+        Bandwidth specification.
+
+    Returns
+    -------
+    Callable[[Any, Any], tuple[float, float]]
+        Callable that computes bandwidths for class 0 and class 1.
     """
     match bandwidth:
         case None:
@@ -83,23 +116,26 @@ def parse_bandwidth(
 
 
 class KDECalibrator(Transformer):
-    """Calculate LR from a score, belonging to one of two distributions using KDE.
+    """
+    Calculate LR from a score, belonging to one of two distributions using KDE.
 
     Calculates a likelihood ratio of a score value, provided it is from one of
     two distributions. Uses kernel density estimation (KDE) for interpolation.
+
+    Parameters
+    ----------
+    bandwidth : Callable | str | float | tuple[float, float] | None, optional
+        Bandwidth specification for KDE.
     """
 
     def __init__(self, bandwidth: Callable | str | float | tuple[float, float] | None = None):
-        """Initialize a new KDECalibrator instance.
+        """
+        Initialize a new KDECalibrator instance.
 
-        :param bandwidth:
-            * If bandwidth has a float value, this value is used as the bandwidth for both distributions.
-            * If bandwidth is a tuple, it should contain two floating point values: the bandwidth for the distribution
-              of the classes with labels 0 and 1, respectively.
-            * If bandwidth has the str value "silverman", Silverman's rule of thumb is used as the bandwidth for both
-              distributions separately.
-            * If bandwidth is callable, it should accept two arguments, `X` and `y`, and return a tuple of two values
-              which are the bandwidths for the two distributions.
+        Parameters
+        ----------
+        bandwidth : Callable | str | float | tuple[float, float] | None, optional
+                Bandwidth specification for KDE.
         """
         self.bandwidth: Callable = parse_bandwidth(bandwidth)
         self._kde0: KernelDensity | None = None
@@ -109,11 +145,20 @@ class KDECalibrator(Transformer):
 
     @staticmethod
     def bandwidth_silverman(X: np.ndarray, y: np.ndarray) -> tuple[float, float]:
-        """Estimate the optimal bandwidth parameter using Silverman's rule of thumb.
+        """
+        Estimate bandwidths using Silverman's rule of thumb.
 
-        :param X: n * 1 np.array of scores
-        :param y: n * 1 np.array of labels (Booleans).
-        :returns: bandwidth for class 0, bandwidth for class 1
+        Parameters
+        ----------
+        X : np.ndarray
+            Score array.
+        y : np.ndarray
+            Label array.
+
+        Returns
+        -------
+        tuple[float, float]
+            Bandwidth for class 0 and class 1.
         """
         assert len(X) > 0 and len(y) > 0
 
@@ -140,7 +185,19 @@ class KDECalibrator(Transformer):
         return bandwidth[0], bandwidth[1]
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the KDE model on the data."""
+        """
+        Fit the KDE model on the data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            Fitted calibrator.
+        """
         instances = check_type(FeatureData, instances)
         instances = instances.replace_as(LLRData)
 
@@ -161,10 +218,18 @@ class KDECalibrator(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Provide LLR's as output.
+        """
+        Provide calibrated LLRs as output.
 
-        :param instances: InstanceData to apply the calibrator to.
-        :returns: LLRData with calibrated log-likelihood ratios.
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to calibrate.
+
+        Returns
+        -------
+        LLRData
+            Calibrated log-likelihood-ratio data.
         """
         if self._kde0 is None or self._kde1 is None or self.numerator is None or self.denominator is None:
             raise ValueError('KDECalibrator.apply() called before fit')

--- a/lir/algorithms/llr_overestimation.py
+++ b/lir/algorithms/llr_overestimation.py
@@ -15,7 +15,8 @@ def plot_llr_overestimation(
     ax: plt.Axes = plt,  # type: ignore
     **kwargs: Any,
 ) -> None:
-    """Plot the LLR-overestimation as function of the system LLR.
+    """
+    Plot LLR-overestimation as a function of the system LLR.
 
     The LLR-overestimation is defined as the log-10 of the ratio between
         (1) the system LRs; the outputs of the LR-system, and
@@ -26,11 +27,16 @@ def plot_llr_overestimation(
     An interval around the LLR-overestimation can be calculated using fiducial distributions. The average absolute
     LLR-overestimation can be used as single metric.
 
-    :param llrdata: An instance of LLRData containing LLRs and ground-truth labels
-    :param num_fids: number of fiducial distributions to base the interval on; use 0 for no interval
-    :param ax: matplotlib axes to plot into
-    :param kwargs: additional arguments to pass to :func:`calc_llr_overestimation`
-        and/or :func:`calc_fiducial_density_functions`.
+    Parameters
+    ----------
+    llrdata : LLRData
+        LLR data containing LLRs and ground-truth labels.
+    num_fids : int, optional
+        Number of fiducial distributions to base the interval on; use 0 for no interval.
+    ax : plt.Axes, optional
+        Matplotlib axes to plot into.
+    **kwargs : Any
+        Additional arguments passed to `calc_llr_overestimation` and/or `calc_fiducial_density_functions`.
     """
     llrs, y = llrdata.llrs, llrdata.labels
     if y is None:
@@ -67,7 +73,8 @@ def calc_llr_overestimation(
     alpha: float = 0.05,
     **kwargs: Any,
 ) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]:
-    """Calculate the LLR-overestimation as function of the system LLR.
+    """
+    Calculate LLR-overestimation as a function of the system LLR.
 
      The LLR-overestimation is defined as the log-10 of the ratio between
         (1) the system LRs; the outputs of the LR-system, and
@@ -80,14 +87,27 @@ def calc_llr_overestimation(
      - The relative frequencies are estimated with KDE using Silverman's rule-of-thumb for the bandwidths.
      - An interval around the LLR-overestimation can be calculated using fiducial distributions.
 
-    :param llrs: the log-10 likelihood ratios (LLRs), as calculated by the LR-system
-    :param y: the corresponding labels (0 for H2 or Hd, 1 for H1 or Hp)
-    :param num_grid_points: number of points used in the grid to calculate the LLR-overestimation on
-    :param bw: two bandwidths for the KDEs of H1 & H2; for each specify a method (string) or a value (float)
-    :param num_fids: number of fiducial distributions to base the interval on; use 0 for no interval
-    :param alpha: level of confidence to use for the interval
-    :param kwargs: additional arguments to pass to :func:`calc_fiducial_density_functions`
-    :returns: a tuple of LLRs, their overestimation (best estimate), and their overestimation interval
+    Parameters
+    ----------
+    llrs : np.ndarray
+        Log10 likelihood ratios as calculated by the LR system.
+    y : np.ndarray
+        Corresponding labels (0 for H2/Hd, 1 for H1/Hp).
+    num_fids : int, optional
+        Number of fiducial distributions used for intervals.
+    bw : tuple[str | float, str | float], optional
+        Bandwidth specifications for KDEs of H1 and H2.
+    num_grid_points : int, optional
+        Number of grid points used for calculating overestimation.
+    alpha : float, optional
+        Confidence level used for the interval.
+    **kwargs : Any
+        Additional arguments passed to `calc_fiducial_density_functions`.
+
+    Returns
+    -------
+    tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]
+        Tuple of LLR grid, overestimation best estimate, and overestimation interval.
     """
     # Convert the LRs to log10 values (LLRs)
     llr_h1 = llrs[y == 1]
@@ -163,16 +183,30 @@ def calc_fiducial_density_functions(
     smoothing_sample_size_correction: float = 1,
     seed: None | int = None,
 ) -> np.ndarray:
-    """Calculate (smoothed) density functions of fiducial distributions of a dataset.
+    """
+    Calculate smoothed density functions of fiducial distributions for a dataset.
 
-    :param data: 1-dimensional array of data points
-    :param grid: 1-dimensional array of equally spaced grid points, at which to calculate the density functions
-    :param df_type: type of density function (df) to generate: either probability ('pdf') or cumulative ('cdf')
-    :param num_fids: number of fiducial distributions to generate
-    :param smoothing_grid_fraction: fraction of grid points to use as half window during smoothing
-    :param smoothing_sample_size_correction: value to use for sample size correction of smoothing window; 0 is no
-        correction
-    :param seed: seed for random number generator used draw samples from a uniform distribution.
+    Parameters
+    ----------
+    data : np.ndarray
+        One-dimensional array of data points.
+    grid : np.ndarray
+        One-dimensional array of equally spaced grid points.
+    df_type : str, optional
+        Density function type: `'pdf'` or `'cdf'`.
+    num_fids : int, optional
+        Number of fiducial distributions to generate.
+    smoothing_grid_fraction : float, optional
+        Fraction of grid points used as half window for smoothing.
+    smoothing_sample_size_correction : float, optional
+        Sample-size correction factor for smoothing window size.
+    seed : int | None, optional
+        Random seed for fiducial sampling.
+
+    Returns
+    -------
+    np.ndarray
+        Density-function values evaluated on `grid`.
     """
     # Generate cdfs of the fiducial distributions: sorted random draws from a uniform distribution
     rng = np.random.default_rng(seed)

--- a/lir/algorithms/logistic_regression.py
+++ b/lir/algorithms/logistic_regression.py
@@ -21,19 +21,37 @@ LOG = logging.getLogger(__name__)
 
 
 class LogitCalibrator(Transformer):
-    """Calculate LR from a score, belonging to one of two distributions using Logistic Regression.
+    """
+    Calculate LR from a score, belonging to one of two distributions using logistic regression.
 
     Calculates a likelihood ratio of a score value, provided it is from one of
     two distributions. Uses logistic regression for interpolation.
 
     Infinite values in the input are ignored, except if they are misleading, which is an error.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Additional keyword arguments forwarded to `sklearn.linear_model.LogisticRegression`.
     """
 
     def __init__(self, **kwargs: dict):
         self._logit = sklearn.linear_model.LogisticRegression(class_weight='balanced', **kwargs)
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the data."""
+        """
+        Fit the model on the data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            Fitted calibrator.
+        """
         instances = check_type(FeatureData, instances)
         if not isinstance(FeatureData, LLRData):
             instances = instances.replace_as(LLRData)
@@ -50,7 +68,19 @@ class LogitCalibrator(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Calculate LLR data from the fitted model, using instance data."""
+        """
+        Calculate LLR data from the fitted model.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to calibrate.
+
+        Returns
+        -------
+        LLRData
+            Calibrated log-likelihood-ratio data.
+        """
         instances = check_type(FeatureData, instances)
         if not isinstance(FeatureData, LLRData):
             instances = instances.replace_as(LLRData)
@@ -72,15 +102,26 @@ class LogitCalibrator(Transformer):
 
 
 def _negative_log_likelihood_balanced(X: np.ndarray, y: np.ndarray, model: Callable, params: list) -> np.ndarray:
-    """Calculate the negative log likelihood (llh) of probabilistic binary classifier.
+    """
+    Calculate the balanced negative log-likelihood of a probabilistic binary classifier.
 
     The llh is balanced in the sense that the total weight of '1'-labels is equal to the total weight of '0'-labels.
 
-    :param X: n * 1 np.array of scores
-    :param y: n * 1 np.array of labels (Booleans). H1 --> 1, H2 --> 0.
-    :param model: model that links score to posterior probabilities
-    :param params: mapping of parameter names to values of the model.
-    :returns: neg_llh_balanced: float, balanced negative log likelihood (base = exp)
+    Parameters
+    ----------
+    X : np.ndarray
+        Score array.
+    y : np.ndarray
+        Label array with values 0 and 1.
+    model : Callable
+        Model that links scores to posterior probabilities.
+    params : list
+        Model parameter values.
+
+    Returns
+    -------
+    np.ndarray
+        Balanced negative log-likelihood values.
     """
     probs = model(X, *params)
     neg_llh_balanced = -np.sum(np.log(probs**y * (1 - probs) ** (1 - y)) / (y * np.sum(y) + (1 - y) * np.sum(1 - y)))
@@ -88,7 +129,8 @@ def _negative_log_likelihood_balanced(X: np.ndarray, y: np.ndarray, model: Calla
 
 
 class FourParameterLogisticCalibrator(Transformer):
-    """Calculate LR of a score, belonging to one of two distributions, using a logistic model.
+    """
+    Calculate LR of a score, belonging to one of two distributions, using a logistic model.
 
     Calculates a likelihood ratio of a score value, provided it is from one of two distributions.
     Depending on the training data, a 2-, 3- or 4-parameter logistic model is used.
@@ -102,8 +144,15 @@ class FourParameterLogisticCalibrator(Transformer):
         """
         Fit the calibrator to data.
 
-        :param instances: InstanceData to fit the calibrator to.
-        :returns: Self
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            Fitted calibrator.
         """
         instances = check_type(FeatureData, instances)
         if not isinstance(FeatureData, LLRData):
@@ -156,10 +205,18 @@ class FourParameterLogisticCalibrator(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Apply the fitted calibrator to new data.
+        """
+        Apply the fitted calibrator to new data.
 
-        :param instances: InstanceData to apply the calibrator to.
-        :returns: LLRData with calibrated log-likelihood ratios.
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to calibrate.
+
+        Returns
+        -------
+        LLRData
+            Calibrated log-likelihood-ratio data.
         """
         if self.coef_ is None:
             raise ValueError('trying to use a model before fitting')
@@ -174,17 +231,28 @@ class FourParameterLogisticCalibrator(Transformer):
 
     @staticmethod
     def _four_pl_model(s: np.ndarray, a: float, b: float, c: float, d: float) -> np.ndarray:
-        """Apply the calculation for a given array of scores.
+        """
+        Apply the four-parameter logistic model to input scores.
 
         4-parameter logistic model that links score to posterior probability.
 
-        :param s: n * 1 np.array of scores
-        :param a: logistic parameter
-        :param b: logistic parameter
-        :param c: floor of posterior probability
-        :param d: ceiling of posterior probability
+        Parameters
+        ----------
+        s : np.ndarray
+            Score array.
+        a : float
+            Logistic parameter.
+        b : float
+            Logistic parameter.
+        c : float
+            Floor of posterior probability.
+        d : float
+            Ceiling of posterior probability.
 
-        :returns p: n * 1 np.array. Posterior probabilities of succes.
+        Returns
+        -------
+        np.ndarray
+            Posterior probabilities of success.
         """
         p = c + ((1 - c) / (1 + d)) * 1 / (1 + np.exp(-a * s - b))
         return p

--- a/lir/algorithms/mcmc.py
+++ b/lir/algorithms/mcmc.py
@@ -20,6 +20,23 @@ class McmcLLRModel(Transformer):
     Using samples from the posterior distributions of the model parameters, a posterior distribution of the LR is
     obtained. The median of this distribution is used as best estimate for the LR; a credible interval is also
     determined.
+
+    Parameters
+    ----------
+    distribution_h1 : str
+        Statistical distribution used to model H1.
+    parameters_h1 : dict[str, dict[str, float | int | str]] | None
+        Parameter definitions and priors for the H1 distribution.
+    distribution_h2 : str
+        Statistical distribution used to model H2.
+    parameters_h2 : dict[str, dict[str, float | int | str]] | None
+        Parameter definitions and priors for the H2 distribution.
+    bounding : Callable[[], LLRBounder] | None, optional
+        Bounding method factory to prevent over-extrapolation.
+    interval : tuple[float, float], optional
+        Lower and upper bounds of the credible interval in range ``[0, 1]``.
+    **mcmc_kwargs : Any
+        Additional MCMC simulation settings passed to `McmcModel`.
     """
 
     def __init__(
@@ -35,13 +52,22 @@ class McmcLLRModel(Transformer):
         """
         Initialise the MCMC model, based on distributions and parameters.
 
-        :param distribution_h1: statistical distribution used to model H1, for example 'normal' or 'binomial'
-        :param parameters_h1: definition of the parameters of distribution_h1, and their prior distributions
-        :param distribution_h2: statistical distribution used to model H2, for example 'normal' or 'binomial'
-        :param parameters_h2: definition of the parameters of distribution_h2, and their prior distributions
-        :param bounding: bounding method to apply to the unbound llrs, to prevent overextrapolation
-        :param interval: lower and upper bounds of the credible interval in range 0..1; default: (0.05, 0.95)
-        :param mcmc_kwargs: mcmc simulation settings, see `McmcModel.__init__` for more details.
+        Parameters
+        ----------
+        distribution_h1 : str
+            Statistical distribution used to model H1.
+        parameters_h1 : dict[str, dict[str, float | int | str]] | None
+            Parameter definitions and priors for the H1 distribution.
+        distribution_h2 : str
+            Statistical distribution used to model H2.
+        parameters_h2 : dict[str, dict[str, float | int | str]] | None
+            Parameter definitions and priors for the H2 distribution.
+        bounding : Callable[[], LLRBounder] | None, optional
+            Bounding method factory to prevent over-extrapolation.
+        interval : tuple[float, float], optional
+            Lower and upper bounds of the credible interval in range ``[0, 1]``.
+        **mcmc_kwargs : Any
+            Additional MCMC simulation settings passed to `McmcModel`.
         """
         self.model_h1 = McmcModel(distribution_h1, parameters_h1, **mcmc_kwargs)
         self.model_h2 = McmcModel(distribution_h2, parameters_h2, **mcmc_kwargs)
@@ -50,7 +76,19 @@ class McmcLLRModel(Transformer):
         self.interval = interval
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the defined model to the supplied instances."""
+        """
+        Fit the defined model to the supplied instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            Fitted model.
+        """
         instances = check_type(FeatureData, instances)
 
         self.model_h1.fit(instances.features[instances.require_labels == 1])
@@ -69,7 +107,19 @@ class McmcLLRModel(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Apply the fitted model to the supplied instances."""
+        """
+        Apply the fitted model to the supplied instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to transform.
+
+        Returns
+        -------
+        LLRData
+            LLR estimates with median and credible interval columns.
+        """
         instances = check_type(FeatureData, instances)
         logp_h1 = self.model_h1.transform(instances.features)
         logp_h2 = self.model_h2.transform(instances.features)
@@ -85,7 +135,31 @@ class McmcLLRModel(Transformer):
 
 
 class McmcModel:
-    """Use Markov Chain Monte Carlo simulations to fit a statistical distribution."""
+    """
+    Use Markov Chain Monte Carlo simulations to fit a statistical distribution.
+
+    Parameters
+    ----------
+    distribution : str
+        Statistical distribution used, for example `'normal'` or `'binomial'`.
+    parameters : dict[str, dict[str, float | int | str]] | None
+        Definitions of distribution parameters and their prior distributions.
+    chain_count : int, optional
+        Number of parallel MCMC chains.
+    tune_count : int, optional
+        Number of tune/warm-up/burn-in samples per chain.
+    draw_count : int, optional
+        Number of posterior draws per chain.
+    random_seed : int | None, optional
+        Random seed.
+
+    Notes
+    -----
+    Supported distributions are `betabinomial`, `binomial`, and `normal`.
+    Parameter names follow the PyMC naming conventions. The `parameters` dictionary maps
+    each model parameter to a prior specification containing a `prior` key and the
+    corresponding prior parameters.
+    """
 
     def __init__(
         self,
@@ -97,25 +171,22 @@ class McmcModel:
         random_seed: int | None = None,
     ):
         """
-        Define the MCMC model and settings to be used.
+        Initialize the MCMC model.
 
-        :param distribution: statistical distribution used, for example 'normal' or 'binomial'
-        :param parameters: definition of the parameters of the distribution, and their prior distributions; see below.
-        :param chain_count: number of parallel mcmc chains
-        :param tune_count: number of tune/warm-up/burn-in samples per chain
-        :param draw_count: number of samples to draw from each chain
-        :param random_seed: random seed
-
-        Currently supported distributions are: 'betabinomial', 'binomial', 'normal'.
-        Names of the parameters are based on the nomenclature used in pymc for distribution parameters:
-        https://www.pymc.io/projects/docs/en/stable/api/distributions.html. The parameters should be provided as a
-        dictionary where the keys are the names of the parameter used for the selected statistical distribution, and the
-        values are dictionaries with a key 'prior', defining the prior distribution used for that parameter (currently
-        supported values are 'beta', 'normal' and 'uniform'), and with additional keys corresponding to the names of the
-        parameters used for that prior distribution (the dict values are the values of these parameters).
-        For example, for a binomial distribution: parameters = {'p': {'prior': 'beta', 'alpha': 0.5, 'beta': 0.5}}.
-        Or for a betabinomial distribution: parameters = {'alpha': {'prior': 'uniform', 'lower': 0.01, 'upper': 100},
-        'beta': {'prior': 'uniform', 'lower': 0.01, 'upper': 100}}.
+        Parameters
+        ----------
+        distribution : str
+            Statistical distribution used for modeling.
+        parameters : dict[str, dict[str, float | int | str]] | None
+            Definitions of distribution parameters and prior distributions.
+        chain_count : int, optional
+            Number of parallel MCMC chains.
+        tune_count : int, optional
+            Number of tune/warm-up samples per chain.
+        draw_count : int, optional
+            Number of posterior draws per chain.
+        random_seed : int | None, optional
+            Random seed for reproducibility.
         """
         self.distribution = distribution.lower()
         self.parameters = parameters
@@ -131,7 +202,15 @@ class McmcModel:
 
         The posteriors are based on the specified prior distributions of these parameters and observed feature values.
 
-        :param features: observed feature values, used to update the prior distributions of the parameters with
+        Parameters
+        ----------
+        features : np.ndarray
+            Observed feature values used to update parameter priors.
+
+        Returns
+        -------
+        Self
+            Fitted model with posterior samples.
         """
         try:
             import pymc as pm
@@ -190,7 +269,15 @@ class McmcModel:
         distribution, to get samples of the posterior distribution of the (log10) probability, evaluated for specified
         feature values.
 
-        :param features: feature values for which the probabilities are to be calculated
+        Parameters
+        ----------
+        features : np.ndarray
+            Feature values for which probabilities are calculated.
+
+        Returns
+        -------
+        np.ndarray
+            Samples of log10 probabilities.
         """
         # Prepare features and parameters for 2d-evaluations (number of samples * number of requested feature values)
         sample_count = len(self.parameter_samples[list(self.parameter_samples.keys())[0]])

--- a/lir/algorithms/percentile_rank.py
+++ b/lir/algorithms/percentile_rank.py
@@ -24,25 +24,27 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
     If ``X`` contains paired measurements per instance (shape
     ``(n_samples, n_features, 2)``), ranking is fitted and applied independently to
     the first and second measurement in the pair.
-
-    Parameters
-    ----------
-    X : numpy.ndarray
-        Input data with shape ``(n_samples, n_features)`` or
-        ``(n_samples, n_features, 2)``.
-
-    Returns
-    -------
-    numpy.ndarray
-        Percentile ranks with the same shape as the input passed to
-        :meth:`transform`.
     """
 
     def __init__(self) -> None:
         self.rank_functions: list[Callable] | None = None
 
     def fit(self, X: np.ndarray, y: np.ndarray | None = None) -> 'PercentileRankTransformer':
-        """Fit the transformer model on the data."""
+        """
+        Fit the transformer model on the data.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Input array with shape ``(n_samples, n_features)`` or ``(n_samples, n_features, 2)``.
+        y : np.ndarray | None, optional
+            Ignored; present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        PercentileRankTransformer
+            Fitted transformer.
+        """
         X = X.reshape(X.shape[0], -1)
         ranks_X = rankdata(X, method='max', axis=0) / X.shape[0]
         self.rank_functions = [
@@ -51,7 +53,19 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
         return self
 
     def transform(self, X: np.ndarray) -> np.ndarray:
-        """Use the fitted model to transform the input data."""
+        """
+        Use the fitted model to transform input data.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Input array with shape ``(n_samples, n_features)`` or ``(n_samples, n_features, 2)``.
+
+        Returns
+        -------
+        np.ndarray
+            Percentile ranks with the same shape as input.
+        """
         assert self.rank_functions, 'transform() called before fit()'
         original_shape = X.shape
         X = X.reshape(X.shape[0], -1)

--- a/lir/bounding.py
+++ b/lir/bounding.py
@@ -13,10 +13,18 @@ LOG = logging.getLogger(__name__)
 
 
 class LLRBounder(Transformer, ABC):
-    """Base class for LLR bounders.
+    """
+    Base class for LLR bounders.
 
     A bounder updates any LLRs that are out of bounds. Any LLR values within bounds remain unchanged. LLR values that
     are out-of-bounds are updated to the nearest bound.
+
+    Parameters
+    ----------
+    lower_llr_bound : float | None
+        The lower bound for the LLRs. If `None`, no lower bound is applied.
+    upper_llr_bound : float | None
+        The upper bound for the LLRs. If `None`, no upper bound is applied.
     """
 
     def __init__(
@@ -29,7 +37,15 @@ class LLRBounder(Transformer, ABC):
 
     @abstractmethod
     def calculate_bounds(self, llrdata: LLRData) -> tuple[float | None, float | None]:
-        """Calculate and returns appropriate bounds for a set of LLRs and their labels."""
+        """
+        Calculate and returns appropriate bounds for a set of LLRs and their labels.
+
+        Parameters
+        ----------
+        llrdata : LLRData
+            The LLR data for which to calculate the bounds. This includes the LLRs,
+            their labels, and any other relevant information.
+        """
         raise NotImplementedError
 
     @staticmethod
@@ -41,9 +57,20 @@ class LLRBounder(Transformer, ABC):
         return instances
 
     def fit(self, instances: InstanceData) -> Self:
-        """Configure this bounder by calculating bounds.
+        """
+        Configure this bounder by calculating bounds.
 
         assuming that y=1 corresponds to Hp, y=0 to Hd
+
+        Parameters
+        ----------
+        instances : InstanceData
+            The data to fit the bounder on. This should include the LLRs and their corresponding labels.
+
+        Returns
+        -------
+        Self
+            The fitted bounder instance.
         """
         instances = self._validate(instances)
 
@@ -67,7 +94,19 @@ class LLRBounder(Transformer, ABC):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Recalculate the LLR data using the first step calibrator and applying the bounds."""
+        """
+        Recalculate the LLR data using the first step calibrator and applying the bounds.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            The data to apply the bounder to. This should include the LLRs and their corresponding labels.
+
+        Returns
+        -------
+        LLRData
+            The LLR data with the LLRs bounded according to the calculated bounds.
+        """
         instances = self._validate(instances)
 
         llrs = instances.features
@@ -81,21 +120,42 @@ class LLRBounder(Transformer, ABC):
 
 
 class StaticBounder(LLRBounder):
-    """Bound LLRs to constant values.
+    """
+    Bound LLRs to constant values.
 
     This bounder takes arguments for a lower and upper bound, which may take `None` in which case no bounds are applied.
+
+    Parameters
+    ----------
+    lower_llr_bound : float | None
+        The lower bound for the LLRs. If `None`, no lower bound is applied.
+    upper_llr_bound : float | None
+        The upper bound for the LLRs. If `None`, no upper bound is applied.
     """
 
     def __init__(self, lower_llr_bound: float | None, upper_llr_bound: float | None):
         super().__init__(lower_llr_bound, upper_llr_bound)
 
     def calculate_bounds(self, llrdata: LLRData) -> tuple[float | None, float | None]:
-        """Calculate and return the lower and upper LLR bounds."""
+        """
+        Calculate and return the lower and upper LLR bounds.
+
+        Parameters
+        ----------
+        llrdata : LLRData
+            Not used, but included for compatibility with the base class.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            The lower and upper LLR bounds, as specified in the constructor.
+        """
         return self.lower_llr_bound, self.upper_llr_bound
 
 
 class NSourceBounder(LLRBounder):
-    """Bound LLRs based on the number of sources.
+    """
+    Bound LLRs based on the number of sources.
 
     This bounder sets the lower LLR bound to -log(N) and the upper bound to log(N), where N is the number of sources.
 
@@ -104,7 +164,19 @@ class NSourceBounder(LLRBounder):
     """
 
     def calculate_bounds(self, llrdata: LLRData) -> tuple[float | None, float | None]:
-        """Calculate and return the lower and upper LLR bounds."""
+        """
+        Calculate and return the lower and upper LLR bounds.
+
+        Parameters
+        ----------
+        llrdata : LLRData
+            The LLR data for which to calculate the bounds. This should include the source IDs.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            The lower and upper LLR bounds, calculated based on the number of sources.
+        """
         if llrdata.source_ids is None:
             raise ValueError(f'{type(self)} requires source IDs to calculate bounds')
 

--- a/lir/config/aggregation.py
+++ b/lir/config/aggregation.py
@@ -25,10 +25,19 @@ def parse_aggregation(
     Other properties are passed as parameters. If `config` is a `str`, then its value is the aggregation method, and it
     has no parameters.
 
-    :param config: the configuration as a dictionary or str
-    :param output_dir: the output directory
-    :param context: the context cof the configuration (if `config` is a str)
-    :return: an Aggregation object
+    Parameters
+    ----------
+    config : ContextAwareDict | str
+        The configuration as a dictionary or string.
+    output_dir : Path
+        Output directory where derived artefacts are written.
+    context : list[str] | None, optional
+        Context for error reporting when ``config`` is provided as a string.
+
+    Returns
+    -------
+    Aggregation
+        Parsed aggregation instance.
     """
     # Normalise configuration into (class_name, args)
     if isinstance(config, str):
@@ -59,10 +68,19 @@ def parse_aggregations(
     """
     Parse a list of configurations for aggregation.
 
-    :param config: the configuration section of a single aggregation, or a list of aggregation configurations
-    :param output_dir: the output directory for the aggregations
-    :param context: the context cof the configuration (if `config` is a `str`)
-    :return: a list of Aggregation objects
+    Parameters
+    ----------
+    config : ContextAwareList | ContextAwareDict | str
+        Configuration for a single aggregation or a list of aggregation configurations.
+    output_dir : Path
+        Output directory for the aggregation instances.
+    context : list[str] | None, optional
+        Context for error reporting when ``config`` is provided as a string.
+
+    Returns
+    -------
+    list[Aggregation]
+        Parsed aggregation instances.
     """
     context = context or getattr(config, 'context', None) or []
     if isinstance(config, list):
@@ -76,9 +94,17 @@ def subset_aggregation(config: ContextAwareDict, output_dir: Path) -> SubsetAggr
     """
     Parse a configuration section for a categorized subset aggregation.
 
-    :param config: the configuration section
-    :param output_dir: the output directory
-    :return: a SubsetAggregation object
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration section.
+    output_dir : Path
+        Output directory.
+
+    Returns
+    -------
+    SubsetAggregation
+        Parsed subset aggregation object.
     """
     check_type(dict, config, 'output configuration should be a dictionary')
     category_field = pop_field(config, 'category_field')

--- a/lir/config/algorithms.py
+++ b/lir/config/algorithms.py
@@ -9,7 +9,21 @@ from lir.util import partial
 
 @config_parser
 def mcmc(config: ContextAwareDict, output_dir: Path) -> McmcLLRModel:
-    """Parse MCMC module config and resolve optional `bounding` to an `LLRBounder` instance."""
+    """
+    Parse MCMC module configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration for the MCMC model.
+    output_dir : Path
+        Output directory used by nested parser calls.
+
+    Returns
+    -------
+    McmcLLRModel
+        Configured MCMC model instance.
+    """
     if 'bounding' in config:
         bounding_config = pop_field(config, 'bounding')
         if bounding_config is None:

--- a/lir/config/base.py
+++ b/lir/config/base.py
@@ -10,39 +10,142 @@ from lir.transform.pairing import PairingMethod
 
 
 class YamlParseError(ValueError):
-    """Error raised when parsing YAML configuration fails, mentioning specific YAML path."""
+    """
+    Error raised when parsing YAML configuration fails, mentioning specific YAML path.
+
+    Parameters
+    ----------
+    config_context_path : list[str]
+        Dot-path to the failing configuration node.
+    message : str
+        Human-readable validation or parsing message.
+    """
 
     def __init__(self, config_context_path: list[str], message: str):
+        """
+        Initialise the parse error.
+
+        Parameters
+        ----------
+        config_context_path : list[str]
+            Dot-path to the failing configuration node.
+        message : str
+            Human-readable validation or parsing message.
+        """
         prefix = f'{".".join(config_context_path)}: ' if config_context_path else ''
         super().__init__(f'{prefix}{message}')
 
 
 class ContextAwareDict(dict):
-    """Dictionary wrapper which has knowledge about its context."""
+    """
+    Dictionary wrapper which has knowledge about its context.
+
+    Parameters
+    ----------
+    context : list[str]
+        YAML path used for contextual error messages.
+    *args : Any
+        Positional arguments passed to ``dict``.
+    **kwargs : Any
+        Keyword arguments passed to ``dict``.
+    """
 
     def __init__(self, context: list[str], *args: Any, **kwargs: Any):
+        """
+        Create a context-aware dictionary.
+
+        Parameters
+        ----------
+        context : list[str]
+            YAML path used for contextual error messages.
+        *args : Any
+            Positional arguments passed to ``dict``.
+        **kwargs : Any
+            Keyword arguments passed to ``dict``.
+        """
         super().__init__(*args, **kwargs)
         self.context = context
 
     def clone(self, context: list[str] | None = None) -> 'ContextAwareDict':
-        """Allow creating a new instance of the ContextAware dictionary, keeping the context."""
+        """
+        Create a cloned dictionary with expanded nested context.
+
+        Parameters
+        ----------
+        context : list[str] | None, optional
+            Replacement context. If omitted, the current context is reused.
+
+        Returns
+        -------
+        ContextAwareDict
+            Cloned and context-aware dictionary.
+        """
         return _expand(context if context is not None else self.context, self)
 
 
 class ContextAwareList(list):
-    """List wrapper which has knowledge about its context."""
+    """
+    List wrapper which has knowledge about its context.
+
+    Parameters
+    ----------
+    context : list[str]
+        YAML path used for contextual error messages.
+    *args : Any
+        Positional arguments passed to ``list``.
+    **kwargs : Any
+        Keyword arguments passed to ``list``.
+    """
 
     def __init__(self, context: list[str], *args: Any, **kwargs: Any):
+        """
+        Create a context-aware list.
+
+        Parameters
+        ----------
+        context : list[str]
+            YAML path used for contextual error messages.
+        *args : Any
+            Positional arguments passed to ``list``.
+        **kwargs : Any
+            Keyword arguments passed to ``list``.
+        """
         super().__init__(*args, **kwargs)
         self.context = context
 
     def clone(self, context: list[str] | None = None) -> 'ContextAwareList':
-        """Allow creating a new instance of the ContextAware dictionary, keeping the context."""
+        """
+        Create a cloned list with expanded nested context.
+
+        Parameters
+        ----------
+        context : list[str] | None, optional
+            Replacement context. If omitted, the current context is reused.
+
+        Returns
+        -------
+        ContextAwareList
+            Cloned and context-aware list.
+        """
         return _expand(context if context is not None else self.context, self)
 
 
 def _expand(context: list[str], cfg: Any) -> Any:
-    """Unpack the data structure iteratively into the appropriate underlying representation."""
+    """
+    Expand nested values into context-aware containers.
+
+    Parameters
+    ----------
+    context : list[str]
+        Current YAML path.
+    cfg : Any
+        Value to expand recursively.
+
+    Returns
+    -------
+    Any
+        Expanded value where mappings and sequences are wrapped in context-aware types.
+    """
     if isinstance(cfg, Mapping):
         return ContextAwareDict(context, [(key, _expand(context + [key], value)) for key, value in cfg.items()])
     elif isinstance(cfg, str):
@@ -53,7 +156,8 @@ def _expand(context: list[str], cfg: Any) -> Any:
 
 
 class ConfigParser(ABC):
-    """Abstract base configuration parser class.
+    """
+    Abstract base configuration parser class.
 
     Each implementation should implement a custom `parse()` method
     which is dedicated to parsing a specific aspect, e.g. the configuration
@@ -66,22 +170,40 @@ class ConfigParser(ABC):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Any:
-        """Dedicated function to parse a specific section of a YAML configuration.
+        """
+        Parse a specific configuration section.
 
-        Arguments:
-        - config: a section of a YAML configuration
-        - config_context_path: the path in the YAML configuration to `config`, the section to be parsed
-        - output_dir: the directory where the returned object may write results during its lifetime
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Configuration section to parse.
+        output_dir : Path
+            Directory where produced outputs may be written.
 
-        Returns: an object that is configured according to `config`.
+        Returns
+        -------
+        Any
+            Object configured from ``config``.
         """
         raise NotImplementedError
 
     @staticmethod
-    def get_type_name(cls: Any) -> str:
-        """Return the full type name of the `cls` argument."""
-        module = cls.__module__
-        return f'{module}.{cls.__qualname__}'
+    def get_type_name(obj: Any) -> str:
+        """
+        Return the fully qualified type name.
+
+        Parameters
+        ----------
+        obj : Any
+            Class or object with ``__module__`` and ``__qualname__`` attributes.
+
+        Returns
+        -------
+        str
+            Fully qualified name.
+        """
+        module = obj.__module__
+        return f'{module}.{obj.__qualname__}'
 
     def reference(self) -> str:
         """
@@ -89,14 +211,34 @@ class ConfigParser(ABC):
 
         By default, return the name of this class. In a subclass that was initialized with another class or function
         that does the actual work, the name of that class is returned.
+
+        Returns
+        -------
+        str
+            Fully qualified class name for this parser instance.
         """
         return self.get_type_name(self.__class__)
 
 
 class GenericFunctionConfigParser(ConfigParser):
-    """Parser for callable functions or component classes."""
+    """
+    Parser for callable functions or component classes.
+
+    Parameters
+    ----------
+    component_class : Callable
+        Callable that should be exposed by this parser.
+    """
 
     def __init__(self, component_class: Callable):
+        """
+        Initialise the parser.
+
+        Parameters
+        ----------
+        component_class : Callable
+            Callable that should be exposed by this parser.
+        """
         super().__init__()
         self.component_class = component_class
 
@@ -105,21 +247,57 @@ class GenericFunctionConfigParser(ConfigParser):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Callable:
-        """Perform the parsing, based on component class."""
+        """
+        Parse configuration into a callable.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Configuration section for validation context.
+        output_dir : Path
+            Unused output directory argument required by the parser API.
+
+        Returns
+        -------
+        Callable
+            Resolved callable object.
+        """
         if callable(self.component_class):
             return self.component_class
 
         raise YamlParseError(config.context, f'unrecognized module type: `{self.component_class}`')
 
     def reference(self) -> str:
-        """Return the full name of the `component_class` function argument."""
+        """
+        Return the fully qualified name of the wrapped callable.
+
+        Returns
+        -------
+        str
+            Fully qualified callable name.
+        """
         return self.get_type_name(self.component_class)
 
 
 class GenericConfigParser(ConfigParser):
-    """Return an instantiation of a class, initialized with the specified arguments."""
+    """
+    Return an instantiation of a class, initialized with the specified arguments.
+
+    Parameters
+    ----------
+    component_class : type[Any]
+        Class to instantiate from configuration values.
+    """
 
     def __init__(self, component_class: type[Any]):
+        """
+        Initialise the parser.
+
+        Parameters
+        ----------
+        component_class : type[Any]
+            Class to instantiate from configuration values.
+        """
         super().__init__()
         self.component_class = component_class
 
@@ -128,7 +306,21 @@ class GenericConfigParser(ConfigParser):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Any:
-        """Perform parsing of a class, based on configuration."""
+        """
+        Instantiate the configured component class.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Keyword arguments for class initialisation.
+        output_dir : Path
+            Unused output directory argument required by the parser API.
+
+        Returns
+        -------
+        Any
+            Instantiated object.
+        """
         try:
             return self.component_class(**config)
         except Exception as e:
@@ -138,7 +330,14 @@ class GenericConfigParser(ConfigParser):
             )
 
     def reference(self) -> str:
-        """Return the full name of the `component_class` class argument."""
+        """
+        Return the fully qualified name of the wrapped class.
+
+        Returns
+        -------
+        str
+            Fully qualified class name.
+        """
         return self.get_type_name(self.component_class)
 
 
@@ -151,6 +350,16 @@ def get_full_name(obj: Any) -> str:
         from lir import FeatureData
         print(get_full_name(FeatureData))
         'lir.FeatureData'
+
+    Parameters
+    ----------
+    obj : Any
+        Importable object.
+
+    Returns
+    -------
+    str
+        Fully qualified object name.
     """
     return f'{obj.__module__}.{obj.__name__}'
 
@@ -181,6 +390,18 @@ def config_parser(
     After decoration, ``foo`` is replaced by a ``ConfigParser`` instance whose
     :meth:`parse` method executes the original function body. See the
     documentation of :class:`ConfigParser` for the meaning of the arguments.
+
+    Parameters
+    ----------
+    func : Callable[[ContextAwareDict, Path], Any] | None, optional
+        Function to wrap as a config parser.
+    reference : str | Any | None, optional
+        Explicit reference name or object used in generated metadata.
+
+    Returns
+    -------
+    Callable
+        Decorator result or wrapped ``ConfigParser`` implementation.
     """
     if func is None:
         # take the optional arguments
@@ -219,7 +440,8 @@ def parse_pairing_config(
     output_dir: Path,
     context: list[str],
 ) -> PairingMethod:
-    """Parse and delegate pairing to the corresponding function for the defined pairing method.
+    """
+    Parse and delegate pairing to the corresponding function for the defined pairing method.
 
     The argument `module_config` defines the pairing method. If its value is a `str`, the registry is queried and the
     corresponding pairing method is returned. If its value is a `dict`, the pairing method is defined
@@ -228,6 +450,20 @@ def parse_pairing_config(
     configuration parser of the pairing method.
 
     If the registry cannot resolve the pairing method, an exception is raised.
+
+    Parameters
+    ----------
+    module_config : ContextAwareDict | str
+        Pairing method configuration.
+    output_dir : Path
+        Output directory for parser calls.
+    context : list[str]
+        Context used when ``module_config`` is a string.
+
+    Returns
+    -------
+    PairingMethod
+        Parsed pairing method.
     """
     if isinstance(module_config, str):
         class_name = module_config
@@ -245,7 +481,21 @@ AnyType = TypeVar('AnyType')
 
 
 def check_not_none[AnyType](v: AnyType | None, message: str | None = None) -> AnyType:
-    """Validate the value to not be equal to None."""
+    """
+    Validate a value is not ``None``.
+
+    Parameters
+    ----------
+    v : AnyType | None
+        Value to validate.
+    message : str | None, optional
+        Error message used when ``v`` is ``None``.
+
+    Returns
+    -------
+    AnyType
+        Original non-``None`` value.
+    """
     if v is None:
         raise ValueError(message or 'value None is not allowed here')
     return v
@@ -274,10 +524,19 @@ def check_type(type_class: Any, v: YamlValueType, message: str | None = None) ->
     - str
     - NoneType
 
-    :param type_class: the target type
-    :param v: the value to check
-    :param message: an optional message that is used in case of an error
-    :return: the value
+    Parameters
+    ----------
+    type_class : Any
+        Target type or tuple of target types.
+    v : YamlValueType
+        Value to validate.
+    message : str | None, optional
+        Error message used when validation fails.
+
+    Returns
+    -------
+    Any
+        Original value when type validation succeeds.
     """
     if isinstance(v, type_class):
         return v
@@ -297,14 +556,24 @@ def pop_field(
     """
     Validate and retrieve the value for a given field, after which it is removed from the configuration.
 
-    :param config: the configuration
-    :param field: the field to obtain from the `config`
-    :param default: the value to return if the field is not found; defaults to `None`; if the value is not `None`, the
-        `required` argument defaults to `False`
-    :param required: if `True` and the field was not found, raise an error; defaults to `True` unless `default` is not
-        `None`
-    :param validate: a callable to validate the value type
-    :return: the field value or the default value or an error is raised
+    Parameters
+    ----------
+    config : ContextAwareDict | Any
+        Configuration object to pop from.
+    field : str
+        Field name to retrieve.
+    default : Any, optional
+        Value to return when ``field`` is absent.
+    required : bool | None, optional
+        Whether to raise when the field is absent. Defaults to ``True`` when
+        ``default`` is ``None``.
+    validate : Callable[[Any], Any] | None, optional
+        Optional validator applied to the popped value.
+
+    Returns
+    -------
+    Any
+        Popped field value or ``default``.
     """
     # get required status and default value from function arguments
     required = required if required is not None else (default is None)
@@ -335,11 +604,24 @@ def check_is_empty(
     config: ContextAwareDict,
     accept_keys: Sequence[str] | None = None,
 ) -> None:
-    """Ensure all defined expected arguments are parsed and warn about ignored arguments.
+    """
+    Ensure all defined expected arguments are parsed and warn about ignored arguments.
 
     If any unexpected arguments remain, a `YamlParseError` is raised indicating the
     argument was unexpected and not taken into account (i.e. not parsed). This methodology ensures
     the user does not assume arguments are parsed that are in fact not recognized.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration to validate for remaining keys.
+    accept_keys : Sequence[str] | None, optional
+        Keys that may remain without raising an error.
+
+    Returns
+    -------
+    None
+        This function raises on invalid input and otherwise returns ``None``.
     """
     for key in config:
         if not accept_keys or key not in accept_keys:

--- a/lir/config/data.py
+++ b/lir/config/data.py
@@ -12,11 +12,24 @@ from lir.data.models import DataProvider, DataStrategy
 
 
 def parse_data_object(cfg: ContextAwareDict, output_path: Path) -> tuple[DataProvider, DataStrategy]:
-    """Parse data provider and data strategy from configuration.
+    """
+    Parse data provider and data strategy from configuration.
 
     The `provider` and `splits` fields are parsed, which are expected to refer
     to specific implementations of `DataProvider` and `DataStrategy`, respectively.
     See `parse_data_provider` and `parse_data_strategy` for more information.
+
+    Parameters
+    ----------
+    cfg : ContextAwareDict
+        Configuration section containing provider and split strategy.
+    output_path : Path
+        Output path for created objects.
+
+    Returns
+    -------
+    tuple[DataProvider, DataStrategy]
+        Parsed data provider and strategy.
     """
     provider, strategy = (
         parse_data_provider(pop_field(cfg, 'provider'), output_path),
@@ -27,13 +40,26 @@ def parse_data_object(cfg: ContextAwareDict, output_path: Path) -> tuple[DataPro
 
 
 def parse_data_strategy(cfg: ContextAwareDict, output_path: Path) -> DataStrategy:
-    """Instantiate specific implementation of `DataStrategy` as configured.
+    """
+    Instantiate specific implementation of `DataStrategy` as configured.
 
     The `strategy` field is parsed, which is expected to refer to a name in
     the registry. See for example `lir.data_setup.binary_cross_validation`
     or `lir.data_setup.binary_train_test_split`.
 
     Data setup configuration is provided under the `data_setup` key.
+
+    Parameters
+    ----------
+    cfg : ContextAwareDict
+        Data strategy configuration.
+    output_path : Path
+        Output path for created objects.
+
+    Returns
+    -------
+    DataStrategy
+        Parsed data strategy instance.
     """
     strategy = pop_field(cfg, 'strategy')
 
@@ -53,13 +79,26 @@ def parse_data_strategy(cfg: ContextAwareDict, output_path: Path) -> DataStrateg
 
 
 def parse_data_provider(cfg: ContextAwareDict, output_path: Path) -> DataProvider:
-    """Instantiate specific implementation of `DataProvider` as configured.
+    """
+    Instantiate specific implementation of `DataProvider` as configured.
 
     The `method` field is parsed, which is expected to refer to a name in
     the registry. See for example `lir.config.data_sources.synthesized_normal_binary`
     or `lir.config.data_sources.synthesized_normal_multiclass`.
 
     Data sources are provided under the `data_sources` key.
+
+    Parameters
+    ----------
+    cfg : ContextAwareDict
+        Data provider configuration.
+    output_path : Path
+        Output path for created objects.
+
+    Returns
+    -------
+    DataProvider
+        Parsed data provider instance.
     """
     provider = pop_field(cfg, 'method')
 

--- a/lir/config/experiment_strategies.py
+++ b/lir/config/experiment_strategies.py
@@ -39,15 +39,28 @@ class ExperimentStrategyConfigParser(ConfigParser, ABC):
         self._output_dir: Path
 
     def primary_metric(self) -> Callable:
-        """Parse the `primary_metric` field."""
+        """
+        Parse the ``primary_metric`` field.
+
+        Returns
+        -------
+        Callable
+            Metric function used for optimisation.
+        """
         metric_name = pop_field(self._config, 'primary_metric')
         return parse_individual_metric(metric_name, self._output_dir, self._config.context)
 
     def output_list(self) -> Sequence[Aggregation]:
-        """Initialize corresponding aggregation classes based on the `output` section.
+        """
+        Initialize corresponding aggregation classes based on the ``output`` section.
 
         The initialized aggregation classes are returned as a sequence, to be iterated over in a
         later stage.
+
+        Returns
+        -------
+        Sequence[Aggregation]
+            Aggregation objects used to collect experiment outputs.
         """
         config: ContextAwareDict = pop_field(self._config, 'output', required=False)
         if not config:
@@ -57,7 +70,19 @@ class ExperimentStrategyConfigParser(ConfigParser, ABC):
 
     @abstractmethod
     def get_experiment(self, name: str) -> Experiment:
-        """Get the experiment by `name` for the defined LR system."""
+        """
+        Get an experiment by name.
+
+        Parameters
+        ----------
+        name : str
+            Experiment name.
+
+        Returns
+        -------
+        Experiment
+            Experiment instance configured by this strategy.
+        """
         raise NotImplementedError
 
     def _parse_config_with_parameters(
@@ -65,11 +90,20 @@ class ExperimentStrategyConfigParser(ConfigParser, ABC):
         config_field: str,
         parameters_field: str,
     ) -> tuple[ContextAwareDict, list[Hyperparameter]]:
-        """Extract a configuration section and its associated parameters.
+        """
+        Extract a configuration section and its associated parameters.
 
-        :param config_field: the name of the field containing the baseline configuration
-        :param parameters_field: the name of the field containing the parameters to vary
-        :return: a tuple of (baseline_config, list of hyperparameters)
+        Parameters
+        ----------
+        config_field : str
+            Field containing the baseline configuration.
+        parameters_field : str
+            Field containing parameters to vary.
+
+        Returns
+        -------
+        tuple[ContextAwareDict, list[Hyperparameter]]
+            Baseline configuration and parsed hyperparameters.
         """
         baseline_config = pop_field(self._config, config_field)
         if baseline_config is None:
@@ -83,17 +117,29 @@ class ExperimentStrategyConfigParser(ConfigParser, ABC):
         return baseline_config, parameters
 
     def data_config(self) -> tuple[ContextAwareDict, list[Hyperparameter]]:
-        """Prepare the data provider and data strategy from the configuration.
+        """
+        Prepare the data provider and data strategy from the configuration.
 
         The (hyper)parameters to vary for the data provider and data strategy are also parsed.
+
+        Returns
+        -------
+        tuple[ContextAwareDict, list[Hyperparameter]]
+            Data configuration and associated hyperparameters.
         """
         return self._parse_config_with_parameters('data', 'dataparameters')
 
     def lrsystem_config(self) -> tuple[ContextAwareDict, list[Hyperparameter]]:
-        """Parse the LR System section including hyperparameters.
+        """
+        Parse the LR system section including hyperparameters.
 
         The baseline configuration is provided along with the specified parameters to vary (the
         defined hyperparameters).
+
+        Returns
+        -------
+        tuple[ContextAwareDict, list[Hyperparameter]]
+            LR system configuration and associated hyperparameters.
         """
         return self._parse_config_with_parameters('lr_system', 'hyperparameters')
 
@@ -102,7 +148,21 @@ class ExperimentStrategyConfigParser(ConfigParser, ABC):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Experiment:
-        """Parse the experiment section of the configuration."""
+        """
+        Parse the experiment section of the configuration.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Experiment strategy configuration.
+        output_dir : Path
+            Base output directory for this experiment.
+
+        Returns
+        -------
+        Experiment
+            Parsed experiment.
+        """
         self._config = config
 
         experiment_name = pop_field(config, 'name', default=f'unnamed_experiment{config.context[-1]}')
@@ -118,7 +178,19 @@ class SingleRunStrategy(ExperimentStrategyConfigParser):
     """Prepare Experiment consisting of a single run using configuration values."""
 
     def get_experiment(self, name: str) -> Experiment:
-        """Get an experiment for a single run, based on its name."""
+        """
+        Get an experiment for a single run.
+
+        Parameters
+        ----------
+        name : str
+            Experiment name.
+
+        Returns
+        -------
+        Experiment
+            Predefined single-run experiment.
+        """
         return PredefinedExperiment(
             name,
             [(pop_field(self._config, 'data'), {})],
@@ -132,18 +204,25 @@ def create_configs_from_hyperparameters(
     baseline_config: ContextAwareDict,
     parameters: list[Hyperparameter],
 ) -> list[tuple[ContextAwareDict, dict[str, Any]]]:
-    """Create configurations for all combinations of hyperparameter options.
+    """
+    Create configurations for all combinations of hyperparameter options.
 
     Generates a Cartesian product of all hyperparameter options and creates a configuration
     for each combination by substituting the values into the baseline configuration.
 
     This is used for both dataparameters and lrsystem hyperparameters in grid search.
 
-    :param baseline_config: the baseline configuration to augment
-    :param parameters: the hyperparameters to vary
-    :return: a list of tuples, where each tuple contains:
-        - the augmented configuration with substituted values
-        - a dict mapping parameter names to the substituted values
+    Parameters
+    ----------
+    baseline_config : ContextAwareDict
+        Baseline configuration to augment.
+    parameters : list[Hyperparameter]
+        Hyperparameters to vary.
+
+    Returns
+    -------
+    list[tuple[ContextAwareDict, dict[str, Any]]]
+        Augmented configurations and applied substitutions.
     """
     configs = []
     parameter_names = [param.name for param in parameters]
@@ -161,7 +240,19 @@ class GridStrategy(ExperimentStrategyConfigParser):
     """Prepare Experiment consisting of multiple runs using configuration values."""
 
     def get_experiment(self, name: str) -> Experiment:
-        """Get experiment for the grid strategy run, based on its name."""
+        """
+        Get experiment for a grid search strategy.
+
+        Parameters
+        ----------
+        name : str
+            Experiment name.
+
+        Returns
+        -------
+        Experiment
+            Predefined experiment with all parameter combinations.
+        """
         lrsystem_configs = create_configs_from_hyperparameters(*self.lrsystem_config())
         data_configs = create_configs_from_hyperparameters(*self.data_config())
 
@@ -178,7 +269,19 @@ class OptunaStrategy(ExperimentStrategyConfigParser):
     """Prepare Experiment for optimizing configuration parameters."""
 
     def get_experiment(self, name: str) -> Experiment:
-        """Get experiment for the optuna run, based on its name."""
+        """
+        Get experiment for an Optuna optimisation strategy.
+
+        Parameters
+        ----------
+        name : str
+            Experiment name.
+
+        Returns
+        -------
+        Experiment
+            Optuna-backed experiment.
+        """
         baseline_config, parameters = self.lrsystem_config()
         n_trials = pop_field(self._config, 'n_trials', validate=int)
 
@@ -195,9 +298,22 @@ class OptunaStrategy(ExperimentStrategyConfigParser):
 
 
 def parse_experiment_strategy(config: ContextAwareDict, output_path: Path) -> Experiment:
-    """Instantiate the corresponding experiment strategy class, e.g. for a single or grid run.
+    """
+    Instantiate the corresponding experiment strategy class, e.g. for a single or grid run.
 
     A corresponding Experiment class is returned.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Experiment strategy configuration.
+    output_path : Path
+        Output path for experiment artefacts.
+
+    Returns
+    -------
+    Experiment
+        Parsed experiment strategy instance.
     """
     strategy_name = pop_field(config, 'strategy')
     strategy_parser = registry.get(strategy_name, search_path=['experiment_strategies'])
@@ -208,9 +324,17 @@ def parse_experiments(cfg: ContextAwareDict, output_path: Path) -> Mapping[str, 
     """
     Extract which Experiment to run as dictated in the configuration.
 
-    :param cfg: a `dict` object describing the experiments
-    :param output_path: the filesystem path to the results directory
-    :return: a mapping of names to experiments
+    Parameters
+    ----------
+    cfg : ContextAwareDict
+        Configuration section describing experiments.
+    output_path : Path
+        Filesystem path to the results directory.
+
+    Returns
+    -------
+    Mapping[str, Experiment]
+        Mapping from experiment name to parsed experiment.
     """
     experiments_config_section = pop_field(cfg, 'experiments', validate=partial(check_type, list))
 

--- a/lir/config/lrsystem_architectures.py
+++ b/lir/config/lrsystem_architectures.py
@@ -29,25 +29,69 @@ LOG = logging.getLogger(__name__)
 
 
 class ParsedLRSystem(LRSystem):
-    """Represent a given initialized LR system based on the provided configuration."""
+    """
+    Represent a given initialized LR system based on the provided configuration.
+
+    Parameters
+    ----------
+    lrsystem : LRSystem
+        Underlying LR system implementation.
+    config : ContextAwareDict
+        Original LR system configuration.
+    """
 
     def __init__(self, lrsystem: LRSystem, config: ContextAwareDict):
+        """
+        Initialise a parsed LR system wrapper.
+
+        Parameters
+        ----------
+        lrsystem : LRSystem
+            Underlying LR system implementation.
+        config : ContextAwareDict
+            Original LR system configuration.
+        """
         self.lrsystem = lrsystem
         self.config = config
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the LR system on the instance data."""
+        """
+        Fit the LR system on instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Training instances.
+
+        Returns
+        -------
+        Self
+            This wrapper instance.
+        """
         self.lrsystem.fit(instances)
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Use the fitted LR system to calculate LLR data for the input instance data."""
+        """
+        Apply the fitted LR system.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Instances to score.
+
+        Returns
+        -------
+        LLRData
+            Computed likelihood-ratio data.
+        """
         return self.lrsystem.apply(instances)
 
 
 @config_parser
 def specific_source(config: ContextAwareDict, output_dir: Path) -> BinaryLRSystem:
-    """Construct a specific-source LR system based on the provided configuration.
+    """
+    Construct a specific-source LR system based on the provided configuration.
 
     The `specific_source` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.specific_source`.
@@ -57,6 +101,18 @@ def specific_source(config: ContextAwareDict, output_dir: Path) -> BinaryLRSyste
      - intermediate_output: boolean flag to determine whether to use logging pipeline as default
 
     If any other fields are present, an exception is raised.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Specific-source architecture configuration.
+    output_dir : Path
+        Output directory passed to nested module parsers.
+
+    Returns
+    -------
+    BinaryLRSystem
+        Configured specific-source LR system.
     """
     pipeline = parse_module(
         pop_field(config, 'modules'), output_dir, config.context, default_method=parse_default_pipeline(config)
@@ -67,7 +123,8 @@ def specific_source(config: ContextAwareDict, output_dir: Path) -> BinaryLRSyste
 
 @config_parser
 def score_based(config: ContextAwareDict, output_dir: Path) -> ScoreBasedSystem:
-    """Construct a score-based LR system based on the provided configuration.
+    """
+    Construct a score-based LR system based on the provided configuration.
 
     The `score_based` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.score_based`.
@@ -79,6 +136,18 @@ def score_based(config: ContextAwareDict, output_dir: Path) -> ScoreBasedSystem:
      - intermediate_output: boolean flag to determine whether to use logging pipeline as default
 
     If any other fields are present, an exception is raised.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Score-based architecture configuration.
+    output_dir : Path
+        Output directory passed to nested module parsers.
+
+    Returns
+    -------
+    ScoreBasedSystem
+        Configured score-based LR system.
     """
     default_pipeline = parse_default_pipeline(config)
 
@@ -96,7 +165,8 @@ def score_based(config: ContextAwareDict, output_dir: Path) -> ScoreBasedSystem:
 
 @config_parser
 def two_level(config: ContextAwareDict, output_dir: Path) -> TwoLevelSystem:
-    """Construct a two-level LR system based on the provided configuration.
+    """
+    Construct a two-level LR system based on the provided configuration.
 
     The `two_level` function name corresponds with the naming scheme in the
     registry. See for example: `lir.config.lrsystems.two_level`.
@@ -110,6 +180,18 @@ def two_level(config: ContextAwareDict, output_dir: Path) -> TwoLevelSystem:
     - intermediate_output: boolean flag to determine whether to use logging pipeline as default
 
     If any other fields are present, an exception is raised.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Two-level architecture configuration.
+    output_dir : Path
+        Output directory passed to nested module parsers.
+
+    Returns
+    -------
+    TwoLevelSystem
+        Configured two-level LR system.
     """
     default_pipeline = parse_default_pipeline(config)
 
@@ -134,9 +216,22 @@ def two_level(config: ContextAwareDict, output_dir: Path) -> TwoLevelSystem:
 
 
 def parse_lrsystem(config: ContextAwareDict, output_dir: Path) -> ParsedLRSystem:
-    """Determine and initialise corresponding LR system from configuration values.
+    """
+    Determine and initialise corresponding LR system from configuration values.
 
     LR systems are provided under the `architectures` key.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        LR system configuration.
+    output_dir : Path
+        Output directory for nested parser calls.
+
+    Returns
+    -------
+    ParsedLRSystem
+        Wrapper containing parsed LR system and source configuration.
     """
     lrsystem_config = config.clone()  # save for later
 
@@ -161,11 +256,17 @@ def augment_config(
     base configuration. Results are written to a subdirectory of `output_dir` that is named by its parameter
     substitutions and prefixed by `dirname_prefix`.
 
-    :param baseline_config: the base LR system configuration
-    :param hyperparameters: hyperparameter substitutions that override parts of the base configuration
-    :param output_dir: the directory where create a results directory
-    :param dirname_prefix: the prefix of the created directory name
-    :return: the LR system
+    Parameters
+    ----------
+    baseline_config : ContextAwareDict
+        Base LR system configuration.
+    hyperparameters : dict[str, HyperparameterOption]
+        Hyperparameter substitutions overriding parts of the base configuration.
+
+    Returns
+    -------
+    ContextAwareDict
+        Augmented LR system configuration.
     """
     substitutions = dict(itertools.chain(*[opt.substitutions.items() for opt in hyperparameters.values()]))
 
@@ -182,10 +283,18 @@ def augment_config(
 
 
 def parse_default_pipeline(config: ContextAwareDict) -> str:
-    """Parse the intermediate result field from configuration, with the goal of determining the default pipeline method.
+    """
+    Parse the intermediate output flag to determine the default pipeline method.
 
-    :param config: the configuration dictionary
-    :return: the default method to use ('logging_pipeline' or 'pipeline')
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration dictionary.
+
+    Returns
+    -------
+    str
+        Default method name (``'logging_pipeline'`` or ``'pipeline'``).
     """
     intermediate_output = pop_field(config, 'intermediate_output', default=False)
     default_method = 'logging_pipeline' if intermediate_output else 'pipeline'

--- a/lir/config/metrics.py
+++ b/lir/config/metrics.py
@@ -7,7 +7,23 @@ from lir.registry import ComponentNotFoundError
 
 
 def parse_individual_metric(name: str, output_path: Path, context: list[str]) -> Callable:
-    """Leverage config parser to interpret `metric` section of the configuration."""
+    """
+    Parse one metric from the registry.
+
+    Parameters
+    ----------
+    name : str
+        Registered metric name.
+    output_path : Path
+        Output path passed to the metric parser.
+    context : list[str]
+        YAML context used for error reporting.
+
+    Returns
+    -------
+    Callable
+        Metric callable.
+    """
     try:
         parser = registry.get(
             name,

--- a/lir/config/substitution.py
+++ b/lir/config/substitution.py
@@ -26,7 +26,7 @@ system configuration used by the pipeline.
               - name: svm
                 method: svm
                 probability: True
-"""  # noqa: D214, D405, D406, D407, D411 (allow for `parameters` in docstring)
+"""  # noqa: D214, D405, D406, D407, D411
 
 import json
 import logging
@@ -93,7 +93,10 @@ class Hyperparameter(ABC):
         """
         Get a list of values that a hyperparameter can take in the context of a particular experiment.
 
-        :return: a list of `HyperparameterOption`
+        Returns
+        -------
+        list[HyperparameterOption]
+            List of options for this hyperparameter.
         """
         raise NotImplementedError
 

--- a/lir/config/substitution.py
+++ b/lir/config/substitution.py
@@ -350,7 +350,8 @@ def parse_parameter(
 def _assign(struct: ContextAwareDict | ContextAwareList, path: list[str], value: Any) -> None:
     """Assign a new value to a path within an hierarchical `dict` structure.
 
-    Parameters:
+    Parameters
+    ----------
     - struct is the `dict` that is modified in-place
     - path is the path within the dict, as a list of `str`
     - value is the value to be assigned

--- a/lir/config/substitution.py
+++ b/lir/config/substitution.py
@@ -68,9 +68,24 @@ class HyperparameterOption(NamedTuple):
 
 
 class Hyperparameter(ABC):
-    """Base class for all hyperparameters."""
+    """
+    Base class for all hyperparameters.
+
+    Parameters
+    ----------
+    name : str
+        Hyperparameter name.
+    """
 
     def __init__(self, name: str):
+        """
+        Initialise a hyperparameter.
+
+        Parameters
+        ----------
+        name : str
+            Hyperparameter name.
+        """
         self.name = name
 
     @abstractmethod
@@ -90,19 +105,59 @@ class CategoricalHyperparameter(Hyperparameter):
     A categorical hyperparameter has the following fields in a YAML configuration:
     - path: the path of this hyperparameter in the LR system configuration
     - options: a list of options
+
+    Parameters
+    ----------
+    name : str
+        Hyperparameter name.
+    options : list[HyperparameterOption]
+        Available options.
     """
 
     def __init__(self, name: str, options: list[HyperparameterOption]):
+        """
+        Initialise a categorical hyperparameter.
+
+        Parameters
+        ----------
+        name : str
+            Hyperparameter name.
+        options : list[HyperparameterOption]
+            Available options.
+        """
         super().__init__(name)
         self._options = options
 
     def options(self) -> list[HyperparameterOption]:
-        """Provide API access to the options for the hyperparameter."""
+        """
+        Provide API access to the options for the hyperparameter.
+
+        Returns
+        -------
+        list[HyperparameterOption]
+            Configured categorical options.
+        """
         return self._options
 
 
 def _parse_categorical_option(spec: Any, path: str, option_index: int | None) -> HyperparameterOption:
-    """Parse a section describing an option value of a categorical hyperparameter."""
+    """
+    Parse one categorical option specification.
+
+    Parameters
+    ----------
+    spec : Any
+        Option specification.
+    path : str
+        Target substitution path.
+    option_index : int | None
+        Position of this option in the list.
+
+    Returns
+    -------
+    HyperparameterOption
+        Parsed option.
+    """
     name = None
     if isinstance(spec, Mapping):
         # use the explicityly declared name, if any
@@ -125,7 +180,21 @@ def _parse_categorical_option(spec: Any, path: str, option_index: int | None) ->
 
 @config_parser(reference='lir.config.substitution.parse_categorical')
 def parse_categorical(spec: ContextAwareDict, output_path: Path) -> 'CategoricalHyperparameter':
-    """Parse the `parameters` section of the configuration into a `CategoricalVariable` object."""
+    """
+    Parse a categorical hyperparameter from configuration.
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Hyperparameter specification.
+    output_path : Path
+        Unused output path required by parser API.
+
+    Returns
+    -------
+    CategoricalHyperparameter
+        Parsed categorical hyperparameter.
+    """
     path = pop_field(spec, 'path')
     name = pop_field(spec, 'name', default=path or 'lrsystem')
 
@@ -138,6 +207,19 @@ def parse_categorical(spec: ContextAwareDict, output_path: Path) -> 'Categorical
 
 
 def _parse_substitution(spec: ContextAwareDict) -> tuple[str, Any]:
+    """
+    Parse one substitution specification.
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Substitution specification with ``path`` and ``value`` fields.
+
+    Returns
+    -------
+    tuple[str, Any]
+        Path and value pair.
+    """
     path = pop_field(spec, 'path')
     value = pop_field(spec, 'value')
     check_is_empty(spec)
@@ -167,6 +249,18 @@ def parse_clustered(spec: ContextAwareDict, output_path: Path) -> CategoricalHyp
     Each option has the following options:
     - name: a descriptive name for this option
     - substitutions: a list of substitutions, with a `path` and `value` field each
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Hyperparameter specification.
+    output_path : Path
+        Unused output path required by parser API.
+
+    Returns
+    -------
+    CategoricalHyperparameter
+        Parsed clustered hyperparameter.
     """
     parameter_name = pop_field(spec, 'name')
     options = pop_field(spec, 'options')
@@ -185,6 +279,18 @@ def parse_constant(spec: ContextAwareDict, output_path: Path) -> CategoricalHype
 
     - path: the path of this hyperparameter in the LR system configuration
     - value: the substitution value
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Hyperparameter specification.
+    output_path : Path
+        Unused output path required by parser API.
+
+    Returns
+    -------
+    CategoricalHyperparameter
+        Parsed constant as a single-option categorical hyperparameter.
     """
     path = pop_field(spec, 'path')
     value = pop_field(spec, 'value')
@@ -205,9 +311,38 @@ class FloatHyperparameter(Hyperparameter):
     - ``step`` (optional): Step size for a linear grid search.
     - ``log`` (optional): If ``True``, search in logarithmic space instead of
     linear space. Cannot be combined with ``step``. Defaults to ``False``.
+
+    Parameters
+    ----------
+    path : str
+        Configuration path to substitute.
+    low : float
+        Lower bound.
+    high : float
+        Upper bound.
+    step : float | None
+        Optional step size for grid options.
+    log : bool
+        Whether to sample in log space.
     """
 
     def __init__(self, path: str, low: float, high: float, step: float | None, log: bool):
+        """
+        Initialise a floating-point hyperparameter.
+
+        Parameters
+        ----------
+        path : str
+            Configuration path to substitute.
+        low : float
+            Lower bound.
+        high : float
+            Upper bound.
+        step : float | None
+            Optional step size for grid options.
+        log : bool
+            Whether to sample in log space.
+        """
         super().__init__(path)
         self.path = path
         self.low = low
@@ -216,7 +351,14 @@ class FloatHyperparameter(Hyperparameter):
         self.log = log
 
     def options(self) -> list[HyperparameterOption]:
-        """Provide API access to the options for the hyperparameter."""
+        """
+        Provide API access to the options for the hyperparameter.
+
+        Returns
+        -------
+        list[HyperparameterOption]
+            Enumerated hyperparameter options.
+        """
         if self.step is None:
             raise ValueError(
                 f'unable to generate options for floating point hyperparameter {self.path}: no step size defined'
@@ -229,7 +371,21 @@ class FloatHyperparameter(Hyperparameter):
 
 @config_parser(reference='lir.config.substitution.parse_float')
 def parse_float(spec: ContextAwareDict, output_path: Path) -> 'FloatHyperparameter':
-    """Parse the `parameters` section of the configuration into a `FloatHyperparameter` object."""
+    """
+    Parse a floating-point hyperparameter from configuration.
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Hyperparameter specification.
+    output_path : Path
+        Unused output path required by parser API.
+
+    Returns
+    -------
+    FloatHyperparameter
+        Parsed floating-point hyperparameter.
+    """
     path = pop_field(spec, 'path')
     low = pop_field(spec, 'low')
     high = pop_field(spec, 'high')
@@ -271,6 +427,15 @@ class FolderHyperparameter(Hyperparameter):
            - '*.tmp'
            - 'ignore_this_file.csv'
 
+    Parameters
+    ----------
+    path : str
+        Configuration path to substitute.
+    folder : str
+        Folder containing candidate files.
+    ignore_files : list[str] | None, optional
+        Filename patterns to exclude.
+
     Raises
     ------
     ValueError
@@ -281,6 +446,18 @@ class FolderHyperparameter(Hyperparameter):
     """
 
     def __init__(self, path: str, folder: str, ignore_files: list[str] | None = None):
+        """
+        Initialise a folder hyperparameter.
+
+        Parameters
+        ----------
+        path : str
+            Configuration path to substitute.
+        folder : str
+            Folder containing candidate files.
+        ignore_files : list[str] | None, optional
+            Filename patterns to exclude.
+        """
         super().__init__(path)
 
         # Search for the folder in the python PATH. Results in an absolute path.
@@ -295,7 +472,14 @@ class FolderHyperparameter(Hyperparameter):
         self.ignore_files = ignore_files if ignore_files is not None else []
 
     def options(self) -> list[HyperparameterOption]:
-        """Generate the options by walking over the folder."""
+        """
+        Generate options by walking over the folder.
+
+        Returns
+        -------
+        list[HyperparameterOption]
+            File-based options discovered in the folder.
+        """
         options = []
         for dirpath, _, filenames in self.folder_path.walk():
             for filename in filenames:
@@ -313,7 +497,21 @@ class FolderHyperparameter(Hyperparameter):
 
 @config_parser(reference='lir.config.substitution.parse_folder')
 def parse_folder(spec: ContextAwareDict, output_path: Path) -> 'FolderHyperparameter':
-    """Parse the `parameters` section of the configuration into a `FolderHyperparameter` object."""
+    """
+    Parse a folder hyperparameter from configuration.
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Hyperparameter specification.
+    output_path : Path
+        Unused output path required by parser API.
+
+    Returns
+    -------
+    FolderHyperparameter
+        Parsed folder hyperparameter.
+    """
     folder = pop_field(spec, 'folder')
     path = pop_field(spec, 'path')
     ignore_files = pop_field(spec, 'ignore_files', required=False)
@@ -325,7 +523,21 @@ def parse_parameter(
     spec: ContextAwareDict,
     output_dir: Path,
 ) -> Hyperparameter:
-    """Parse the parameters section of the configuration into a dedicated value wrapper object."""
+    """
+    Parse one parameter specification into a hyperparameter object.
+
+    Parameters
+    ----------
+    spec : ContextAwareDict
+        Parameter specification.
+    output_dir : Path
+        Output directory used by nested parser calls.
+
+    Returns
+    -------
+    Hyperparameter
+        Parsed hyperparameter object.
+    """
     if 'type' in spec:
         parameter_type = pop_field(spec, 'type')  # read from specified configuration
 
@@ -348,13 +560,22 @@ def parse_parameter(
 
 
 def _assign(struct: ContextAwareDict | ContextAwareList, path: list[str], value: Any) -> None:
-    """Assign a new value to a path within an hierarchical `dict` structure.
+    """
+    Assign a new value to a path within an hierarchical `dict` structure.
 
     Parameters
     ----------
-    - struct is the `dict` that is modified in-place
-    - path is the path within the dict, as a list of `str`
-    - value is the value to be assigned
+    struct : ContextAwareDict | ContextAwareList
+        Structure that is modified in-place.
+    path : list[str]
+        Path within the structure.
+    value : Any
+        Value to assign.
+
+    Returns
+    -------
+    None
+        This function mutates ``struct`` in-place.
     """
     if isinstance(struct, list):
         index = int(path[0])
@@ -395,10 +616,19 @@ def substitute_parameters(
     """
     Substitute parameters in an LR system configuration and return the updated configuration.
 
-    :param base_config: the original LR system configuration
-    :param hyperparameters: the hyperparameters and their values
-    :param context: the context path of the augmented configuration
-    :return: the augmented LR system configuration
+    Parameters
+    ----------
+    base_config : ContextAwareDict
+        Original LR system configuration.
+    hyperparameters : Mapping[str, Any]
+        Hyperparameters and their replacement values.
+    context : list[str]
+        Context path of the augmented configuration.
+
+    Returns
+    -------
+    ContextAwareDict
+        Augmented LR system configuration.
     """
     if '' in hyperparameters:
         # if the root is assigned, don't bother substituting and return the assigned value immediately

--- a/lir/config/transform.py
+++ b/lir/config/transform.py
@@ -22,16 +22,30 @@ from lir.transform import (
 
 
 class GenericTransformerConfigParser(ConfigParser):
-    """Parser class to help parse the defined component into its corresponding `Transformer` object.
+    """
+    Parser class to help parse the defined component into its corresponding `Transformer` object.
 
     Since the scikit-learn `Pipeline` expects a `fit()` and `transform()` method on each of the pipeline steps,
     the configured components should adhere to this contract and implement these methods.
 
     The `parse()` function offered in this helper class, implements a branching strategy to determine
     which strategy is best suited to make the component compatible with the scikit-learn pipeline.
+
+    Parameters
+    ----------
+    component_class : object
+        Component class or callable to adapt to the transformer interface.
     """
 
     def __init__(self, component_class: object):
+        """
+        Initialise parser for a transformer-like component.
+
+        Parameters
+        ----------
+        component_class : object
+            Component class or callable to adapt to the transformer interface.
+        """
         super().__init__()
         self.component_class = component_class
 
@@ -40,7 +54,21 @@ class GenericTransformerConfigParser(ConfigParser):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Transformer:
-        """Prepare the defined component to support the expected methods in the scikit-learn `Pipeline`."""
+        """
+        Prepare a configured component for use in a scikit-learn pipeline.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Constructor arguments for the component class.
+        output_dir : Path
+            Unused output directory argument required by parser API.
+
+        Returns
+        -------
+        Transformer
+            Component adapted to the ``Transformer`` interface.
+        """
         if inspect.isclass(self.component_class):
             try:
                 instance = self.component_class(**config)
@@ -76,14 +104,43 @@ class GenericTransformerConfigParser(ConfigParser):
 
 
 class NumpyWrappingConfigParser(ConfigParser):
-    """Wrap a Transformer to add a header to FeatureData."""
+    """
+    Wrap a Transformer to add a header to FeatureData.
+
+    Parameters
+    ----------
+    module_parser : ConfigParser
+        Parser used to create the wrapped transformer.
+    """
 
     def __init__(self, module_parser: ConfigParser):
+        """
+        Initialise parser that wraps module output in ``NumpyTransformer``.
+
+        Parameters
+        ----------
+        module_parser : ConfigParser
+            Parser used to create the wrapped transformer.
+        """
         super().__init__()
         self.module_parser = module_parser
 
     def parse(self, config: ContextAwareDict, output_dir: Path) -> Transformer:
-        """Parse the provided header configuration."""
+        """
+        Parse the provided header configuration.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Configuration possibly containing ``header`` and module fields.
+        output_dir : Path
+            Output directory passed to the wrapped parser.
+
+        Returns
+        -------
+        Transformer
+            Wrapped transformer that preserves numpy headers.
+        """
         header = config.pop('header') if 'header' in config else None
         return NumpyTransformer(
             self.module_parser.parse(config, output_dir),
@@ -91,7 +148,14 @@ class NumpyWrappingConfigParser(ConfigParser):
         )
 
     def reference(self) -> str:
-        """Return the full name of the `module_parser` class argument."""
+        """
+        Return the full name of the ``module_parser`` class argument.
+
+        Returns
+        -------
+        str
+            Reference string for the wrapped parser.
+        """
         return self.module_parser.reference()
 
 
@@ -126,13 +190,13 @@ def parse_module(
 
     Parameters
     ----------
-    module_config : dict or str or None
+    module_config : ContextAwareDict | str | None
         Specification of the module.
-    output_dir : str or pathlib.Path
+    output_dir : Path
         Directory where any output produced by the module is written.
-    config_context_path : str
+    config_context_path : list[str]
         Context path of this configuration, used for error reporting.
-    default_method : str, optional
+    default_method : str | None, optional
         Default value for the ``method`` field if it is not provided.
 
     Returns
@@ -154,7 +218,21 @@ def parse_module(
 
 @config_parser
 def csv_writer(config: ContextAwareDict, output_dir: Path) -> CsvWriter:
-    """Set up a CSV Writer object, according to the configuration."""
+    """
+    Set up a CSV writer from configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        CSV writer configuration.
+    output_dir : Path
+        Output directory used to derive default CSV path.
+
+    Returns
+    -------
+    CsvWriter
+        Configured CSV writer.
+    """
     if 'path' not in config:
         config |= {'path': output_dir / f'{config.context[-1]}.csv'}
     return CsvWriter(**config)

--- a/lir/config/util.py
+++ b/lir/config/util.py
@@ -14,7 +14,21 @@ class TeeParser(ConfigParser):
         config: ContextAwareDict,
         output_dir: Path,
     ) -> Any:
-        """Read configuration for modules section and provide wrapped corresponding transformers."""
+        """
+        Read configuration for modules section and provide wrapped corresponding transformers.
+
+        Parameters
+        ----------
+        config : ContextAwareDict
+            Configuration for the `Tee` transformer, containing a `modules` field with a list of module configurations.
+        output_dir : Path
+            Output directory for the parsed modules.
+
+        Returns
+        -------
+        Any
+            A `Tee` transformer wrapping the parsed modules.
+        """
         transformers = []
         modules = pop_field(config, 'modules')
         for module_config in modules:
@@ -24,9 +38,20 @@ class TeeParser(ConfigParser):
 
 
 def simplify_data_structure(data: Any) -> dict | list | str | float | int | bool | None:
-    """Simplify data structure: specialized data types are replaced.
+    """
+    Simplify data structure: specialized data types are replaced.
 
     For example, `ContextAwareDict` is replaced by `dict`.
+
+    Parameters
+    ----------
+    data : Any
+        Input data to simplify.
+
+    Returns
+    -------
+    dict | list | str | float | int | bool | None
+        Simplified structure containing only plain Python container and scalar types.
     """
     match data:
         case dict():

--- a/lir/data/io.py
+++ b/lir/data/io.py
@@ -13,9 +13,17 @@ LOG = logging.getLogger(__name__)
 
 
 class RemoteResource:
-    """Provide method to open files from remote source.
+    """
+    Provide method to open files from remote source.
 
     This can be handy if any resource is located on e.g. a GitHub repository.
+
+    Parameters
+    ----------
+    url : str
+        URL of the remote resource to read.
+    local_directory : Path
+        Local cache directory used for downloaded data.
     """
 
     def __init__(self, url: str, local_directory: Path):
@@ -23,7 +31,21 @@ class RemoteResource:
         self.local_directory = local_directory
 
     def open(self, filename: str, mode: str = 'r') -> IO[Any]:
-        """Return an open file stream for a remote resource."""
+        """
+        Return an open file stream for a remote resource.
+
+        Parameters
+        ----------
+        filename : str
+            Filename to open from disk.
+        mode : str
+            Value passed via ``mode``.
+
+        Returns
+        -------
+        IO[Any]
+            Open file handle for the requested resource.
+        """
         local_path = self.local_directory / filename
         if not local_path.exists():
             url = f'{self.url}/{filename}'
@@ -35,9 +57,19 @@ class RemoteResource:
 
 
 class DataFileBuilderCsv:
-    """DataFileBuilderCsv Class.
+    """
+    DataFileBuilderCsv Class.
 
     This class adds convenience methods to write data to an output CSV file.
+
+    Parameters
+    ----------
+    path : Path
+        Filesystem path used by this operation.
+    write_mode : str
+        File mode used when writing output data.
+    write_header : bool | None
+        Whether to write a header row before data rows.
     """
 
     def __init__(self, path: Path, write_mode: str = 'w', write_header: bool | None = None):
@@ -60,9 +92,17 @@ class DataFileBuilderCsv:
         length of the dimension. If it is `list[str]`, it is a meaningful header for the dimension and its length is
         equal to the size of the dimension.
 
-        :param prefix: prefix for all headers
-        :param dimensions: dimension of each row in the data
-        :return: a flattened array of headers
+        Parameters
+        ----------
+        prefix : str
+            Prefix used when generating column names.
+        dimensions : list[int | list[str]]
+            Number of feature dimensions to include in the header.
+
+        Returns
+        -------
+        list[str]
+            Flattened list of generated header names.
         """
         full_shape = [d if isinstance(d, int) else len(d) for d in dimensions]
         full_header = np.full(shape=full_shape, fill_value=prefix)
@@ -100,10 +140,16 @@ class DataFileBuilderCsv:
         The data argument is an arbitrary numpy array. Its first dimension are the rows. Any other dimension will be
         columns in the CSV output.
 
-        :param header_prefix: the prefix for all headers
-        :param dimension_headers: a mapping from dimensions to its headers; the dimension corresponds to the dimensions
             of the data. Because dimension 0 corresponds to rows, it should have no headers
-        :param data:
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Data object to be written or transformed.
+        header_prefix : str
+            Prefix used for generated header names.
+        dimension_headers : dict[int, list[str]] | None
+            Optional explicit names for feature dimensions.
         """
         dimension_headers = dimension_headers or {}
 
@@ -155,6 +201,16 @@ def search_path(path: Path) -> Path:
     elements one by one, and if it exists, it is normalized by `Path.resolve()` and returned.
 
     If the file is not found, it is normalized and made absolute by `Path.resolve()` and returned.
+
+    Parameters
+    ----------
+    path : Path
+        Filesystem path used by this operation.
+
+    Returns
+    -------
+    Path
+        Absolute path to the resolved file location.
     """
     if path.is_absolute():
         return path.resolve()

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -13,7 +13,19 @@ LOG = logging.getLogger(__name__)
 
 
 def _validate_labels(labels: np.ndarray | None) -> np.ndarray | None:
-    """Check if labels have the correct shape."""
+    """
+    Check if labels have the correct shape.
+
+    Parameters
+    ----------
+    labels : np.ndarray | None
+        Value passed via ``labels``.
+
+    Returns
+    -------
+    np.ndarray | None
+        Validated label array, or ``None`` when labels are absent.
+    """
     if labels is None:
         return labels
 
@@ -27,7 +39,19 @@ def _validate_labels(labels: np.ndarray | None) -> np.ndarray | None:
 
 
 def _validate_source_ids(source_ids: np.ndarray | None) -> np.ndarray | None:
-    """Check if source_ids have the correct shape."""
+    """
+    Check if source_ids have the correct shape.
+
+    Parameters
+    ----------
+    source_ids : np.ndarray | None
+        Value passed via ``source_ids``.
+
+    Returns
+    -------
+    np.ndarray | None
+        Validated source-id array, or ``None`` when source IDs are absent.
+    """
     if source_ids is None:
         return source_ids
 
@@ -81,14 +105,28 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def require_labels(self) -> np.ndarray:
-        """Returns `labels` and guarantee that it is not None (or raise an error)."""
+        """
+        Return `labels` and guarantee that it is not None (or raise an error).
+
+        Returns
+        -------
+        np.ndarray
+            Label array guaranteed to contain values for both hypotheses.
+        """
         if self.labels is None:
             raise ValueError('labels not set')
         return self.labels
 
     @model_validator(mode='after')
     def check_sourceids_labels_match(self) -> Self:
-        """Validate the source_ids and labels have matching shapes."""
+        """
+        Validate the source_ids and labels have matching shapes.
+
+        Returns
+        -------
+        Self
+            This instance data object after post-init validation.
+        """
         if self.labels is not None and self.source_ids is not None and self.labels.shape[0] != self.source_ids.shape[0]:
             raise ValueError(
                 f'dimensions of labels and source_ids do not match; "'
@@ -99,7 +137,14 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def source_ids_1d(self) -> np.ndarray:
-        """:return: the attribute `source_ids` as a 1-dimensional array, with one source id per instance."""
+        """
+        Return source identifiers as a one-dimensional array.
+
+        Returns
+        -------
+        np.ndarray
+            One-dimensional source-id array with one source per instance.
+        """
         if self.source_ids is None:
             raise ValueError('source_ids not available')
         if len(self.source_ids.shape) != 1:
@@ -108,7 +153,14 @@ class InstanceData(BaseModel, ABC):
 
     @abstractmethod
     def __len__(self) -> int:
-        """:return: the number of instances in this dataset."""
+        """
+        Return the number of instances in this dataset.
+
+        Returns
+        -------
+        int
+            Number of instances represented by this object.
+        """
         raise NotImplementedError
 
     def __getitem__(self, indexes: np.ndarray | int) -> Self:
@@ -118,8 +170,15 @@ class InstanceData(BaseModel, ABC):
         All `ndarray` fields are indexed using `indexes`.
         All other fields are taken as-is.
 
-        :param indexes: the indexes to select
-        :return: a subset of this dataset
+        Parameters
+        ----------
+        indexes : np.ndarray | int
+            Value passed via ``indexes``.
+
+        Returns
+        -------
+        Self
+            New instance data object containing only selected rows.
         """
         data = {}
         for field in self.all_fields:
@@ -141,8 +200,12 @@ class InstanceData(BaseModel, ABC):
         """
         Return labels or raise an error if they are missing or if they do not represent both hypotheses.
 
-        :return: the labels
         :raise: ValueError if hypothesis labels are missing or either label is not represented.
+
+        Returns
+        -------
+        np.ndarray
+            Label array containing both classes 0 and 1.
         """
         if self.labels is None:
             raise ValueError('labels not set')
@@ -178,6 +241,16 @@ class InstanceData(BaseModel, ABC):
         Numpy fields are concatenated using `np.concatenate`. Other fields are copied as-is.
 
         Returns a new object with the concatenated instances.
+
+        Parameters
+        ----------
+        *others : 'InstanceData'
+            Value passed via ``others``.
+
+        Returns
+        -------
+        Self
+            New instance data object with concatenated rows.
         """
         for instances in others:
             if not self.has_same_type(instances):
@@ -201,6 +274,16 @@ class InstanceData(BaseModel, ABC):
         - `other` has the same class
         - `other` has the same fields
         - all fields have the same type
+
+        Parameters
+        ----------
+        other : Any
+            Value passed via ``other``.
+
+        Returns
+        -------
+        bool
+            ``True`` when type, fields, and field value types all match.
         """
         if type(self) is not type(other):
             return False
@@ -220,6 +303,22 @@ class InstanceData(BaseModel, ABC):
 
         All objects must have the same types and fields, and the same values for all non-numpy array
         fields, or an error is raised. Numpy fields are concatenated using `fn`. Other fields are copied as-is.
+
+        Parameters
+        ----------
+        others : 'list[InstanceData] | InstanceData'
+            Value passed via ``others``.
+        fn : Callable
+            Value passed via ``fn``.
+        *args : Any
+            Additional positional arguments forwarded to the underlying call.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
+
+        Returns
+        -------
+        Self
+            New instance data object after applying the combination function.
         """
         if isinstance(others, InstanceData):
             others = [others]
@@ -265,6 +364,20 @@ class InstanceData(BaseModel, ABC):
         Apply a custom function to this InstanceData object.
 
         The function `fn` is applied to all Numpy fields. Other fields are copied as-is.
+
+        Parameters
+        ----------
+        fn : Callable
+            Value passed via ``fn``.
+        *args : Any
+            Additional positional arguments forwarded to the underlying call.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
+
+        Returns
+        -------
+        Self
+            New instance data object after applying the function to numpy fields.
         """
         # initialize the dictionary of fields to be updated
         data: dict[str, np.ndarray | None] = {}
@@ -291,6 +404,16 @@ class InstanceData(BaseModel, ABC):
         - the method `has_same_type()` returns `True`
         - all numpy fields in `other` have the same shape and the same values
         - all other fields are compared using the `!=` operator
+
+        Parameters
+        ----------
+        other : Any
+            Value passed via ``other``.
+
+        Returns
+        -------
+        bool
+            ``True`` when all fields are equal under the class comparison rules.
         """
         if not self.has_same_type(other):
             return False
@@ -309,7 +432,14 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def all_fields(self) -> list[str]:
-        """:return: a list of all fields, including both mandatory and extra fields."""
+        """
+        Return all available field names for this data object.
+
+        Returns
+        -------
+        list[str]
+            Names of all standard and extra fields available on the instance.
+        """
         all_fields = list(type(self).model_fields.keys())
         if self.model_extra:
             all_fields += list(self.model_extra.keys())
@@ -317,15 +447,29 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def has_labels(self) -> bool:
-        """:return: True iff the instances are labeled."""
+        """
+        Indicate whether label values are available.
+
+        Returns
+        -------
+        bool
+            ``True`` when label information is present.
+        """
         return self.labels is not None
 
     def replace(self, **kwargs: Any) -> Self:
         """
         Return a modified copy with updated values.
 
-        :param kwargs: the fields to replace
-        :return: the modified copy
+        Parameters
+        ----------
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
+
+        Returns
+        -------
+        Self
+            Copy of this object with the provided fields replaced.
         """
         return self.replace_as(type(self), **kwargs)
 
@@ -333,9 +477,17 @@ class InstanceData(BaseModel, ABC):
         """
         Return a modified copy with updated data type and values.
 
-        :param datatype: the return type
-        :param kwargs: the fields to replace
-        :return: the modified copy
+        Parameters
+        ----------
+        datatype : type['InstanceDataType']
+            Value passed via ``datatype``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
+
+        Returns
+        -------
+        'InstanceDataType'
+            Instance data object produced by this operation.
         """
         args = self.model_dump()
         args.update(kwargs)
@@ -343,7 +495,19 @@ class InstanceData(BaseModel, ABC):
 
 
 def _validate_features(features: np.ndarray) -> np.ndarray:
-    """Check if labels have the correct shape."""
+    """
+    Check if labels have the correct shape.
+
+    Parameters
+    ----------
+    features : np.ndarray
+        Value passed via ``features``.
+
+    Returns
+    -------
+    np.ndarray
+        Feature array reshaped to at least two dimensions.
+    """
     if len(features.shape) < 2:
         LOG.debug(f'1d features are silently converted to 2d; found shape: {features.shape}')
         features = np.expand_dims(features, axis=1)
@@ -375,7 +539,14 @@ class FeatureData(InstanceData):
 
     @model_validator(mode='after')
     def check_matching_shapes(self) -> Self:
-        """Validate the shape of the features and the labels are matching."""
+        """
+        Validate the shape of the features and the labels are matching.
+
+        Returns
+        -------
+        Self
+            This feature-data object after shape consistency checks.
+        """
         if self.labels is not None and self.labels.shape[0] != self.features.shape[0]:
             raise ValueError(
                 f'dimensions of labels and features do not match; {self.labels.shape[0]} != {self.features.shape[0]}'
@@ -389,7 +560,14 @@ class FeatureData(InstanceData):
 
     @model_validator(mode='after')
     def check_features(self) -> Self:
-        """Validate the features."""
+        """
+        Validate the features.
+
+        Returns
+        -------
+        Self
+            This feature-data object after numeric type validation.
+        """
         if not np.issubdtype(self.features.dtype, np.number):
             raise ValueError(f'features should be numeric; found: {self.features.dtype}')
         return self
@@ -429,34 +607,76 @@ class PairedFeatureData(FeatureData):
 
     @property
     def features_trace(self) -> np.ndarray:
-        """Get the features of the trace instances."""
+        """
+        Get the features of the trace instances.
+
+        Returns
+        -------
+        np.ndarray
+            Feature tensor slice containing trace-instance features.
+        """
         return self.features[:, : self.n_trace_instances]
 
     @property
     def features_ref(self) -> np.ndarray:
-        """Get the features of the reference instances."""
+        """
+        Get the features of the reference instances.
+
+        Returns
+        -------
+        np.ndarray
+            Feature tensor slice containing reference-instance features.
+        """
         return self.features[:, self.n_trace_instances :]  # noqa: E203
 
     @property
     def source_ids_trace(self) -> np.ndarray | None:
-        """Get the source ids of the trace instances."""
+        """
+        Get the source ids of the trace instances.
+
+        Returns
+        -------
+        np.ndarray | None
+            Trace source IDs when available, otherwise ``None``.
+        """
         return self.source_ids[:, 0] if self.source_ids else None
 
     @property
     def source_ids_ref(self) -> np.ndarray | None:
-        """Get the source ids of the reference instances."""
+        """
+        Get the source ids of the reference instances.
+
+        Returns
+        -------
+        np.ndarray | None
+            Reference source IDs when available, otherwise ``None``.
+        """
         return self.source_ids[:, 1] if self.source_ids else None
 
     @model_validator(mode='after')
     def check_sourceid_shape(self) -> Self:
-        """Override the `InstanceData` implementation."""
+        """
+        Override the `InstanceData` implementation.
+
+        Returns
+        -------
+        Self
+            This paired-feature object after source-id shape validation.
+        """
         if self.source_ids is not None and (len(self.source_ids.shape) != 2 or self.source_ids.shape[1] != 2):
             raise ValueError(f'source_ids should be 2-dimensional with 2 columns; found shape {self.source_ids.shape}')
         return self
 
     @model_validator(mode='after')
     def check_features_dimensions(self) -> Self:
-        """Validate feature dimensions."""
+        """
+        Validate feature dimensions.
+
+        Returns
+        -------
+        Self
+            This paired-feature object after feature-dimension validation.
+        """
         if len(self.features.shape) < 3:
             raise ValueError(f'features should have 3 or more dimensions; found shape: {self.features.shape}')
         if self.features.shape[1] != self.n_trace_instances + self.n_ref_instances:
@@ -493,7 +713,14 @@ class LLRData(FeatureData):
 
     @property
     def llrs(self) -> np.ndarray:
-        """:return: 1-dimensional numpy array of LLR values."""
+        """
+        Return the core LLR values.
+
+        Returns
+        -------
+        np.ndarray
+            One-dimensional array containing the central LLR values.
+        """
         if len(self.features.shape) == 1:
             return self.features
         else:
@@ -501,12 +728,26 @@ class LLRData(FeatureData):
 
     @property
     def has_intervals(self) -> bool:
-        """:return: indicate whether the LLR's have intervals."""
+        """
+        Indicate whether interval bounds are present for each LLR.
+
+        Returns
+        -------
+        bool
+            ``True`` when lower and upper interval bounds are included.
+        """
         return len(self.features.shape) == 2 and self.features.shape[1] == 3
 
     @property
     def llr_intervals(self) -> np.ndarray | None:
-        """:return: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals."""
+        """
+        Return interval bounds for each LLR when available.
+
+        Returns
+        -------
+        np.ndarray | None
+            Two-column array with lower and upper LLR bounds, if available.
+        """
         if self.has_intervals:
             return self.features[:, 1:]
         else:
@@ -514,12 +755,26 @@ class LLRData(FeatureData):
 
     @property
     def llr_bounds(self) -> tuple[float | None, float | None]:
-        """:return: a tuple (min_llr, max_llr)."""
+        """
+        Return global lower and upper bounds applied to LLR values.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            Tuple containing global lower and upper LLR clipping bounds.
+        """
         return self.llr_lower_bound, self.llr_upper_bound
 
     @model_validator(mode='after')
     def check_features_are_llrs(self) -> Self:
-        """Validate the feature data."""
+        """
+        Validate the feature data.
+
+        Returns
+        -------
+        Self
+            This LLR object after validating LLR-specific feature constraints.
+        """
         if len(self.features.shape) > 2:
             raise ValueError(f'features must have 1 or 2 dimensions; shape: {self.features.shape}')
 
@@ -537,10 +792,23 @@ class LLRData(FeatureData):
 
     @classmethod
     def _concatenate_field(cls, field: str, values: list[Any]) -> Any:
-        """Remove `llr_upper_bound` and `llr_lower_bound` when having different values.
+        """
+        Remove `llr_upper_bound` and `llr_lower_bound` when having different values.
 
         The fields `llr_upper_bound` and `llr_lower_bound` may have different values which is not allowed by default.
         Remove them instead of trying to combine them.
+
+        Parameters
+        ----------
+        field : str
+            Value passed via ``field``.
+        values : list[Any]
+            Value passed via ``values``.
+
+        Returns
+        -------
+        Any
+            Concatenated field value with LLR-bound handling for mixed values.
         """
         match field:
             case 'llr_upper_bound' | 'llr_lower_bound':
@@ -572,22 +840,43 @@ FeatureDataType = TypeVar('FeatureDataType', bound=FeatureData)
 
 
 def concatenate_instances(first: InstanceDataType, *others: InstanceDataType) -> InstanceDataType:
-    """Concatenate the results of the InstanceData objects.
+    """
+    Concatenate the results of the InstanceData objects.
 
     Alias for `first.concatenate(*others)`.
+
+    Parameters
+    ----------
+    first : InstanceDataType
+        Value passed via ``first``.
+    *others : InstanceDataType
+        Value passed via ``others``.
+
+    Returns
+    -------
+    InstanceDataType
+        Instance data object produced by this operation.
     """
     return first.concatenate(*others)
 
 
 class DataProvider(ABC):
-    """Base class for data providers.
+    """
+    Base class for data providers.
 
     Each data provider should provide access to instance data by implementing the `get_instances()` method.
     """
 
     @abstractmethod
     def get_instances(self) -> InstanceData:
-        """Return an InstanceData object, containing data for a set of instances."""
+        """
+        Return an InstanceData object, containing data for a set of instances.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         raise NotImplementedError
 
 
@@ -596,10 +885,21 @@ class DataStrategy(ABC):
 
     @abstractmethod
     def apply[DataType: InstanceData](self, instances: DataType) -> Iterable[tuple[DataType, DataType]]:
-        """Provide iterator to access training and test set.
+        """
+        Provide iterator to access training and test set.
 
         Returns an iterator over tuples of a training set and a test set. Both the training set and the test
         is represented by an `InstanceData` object.
+
+        Parameters
+        ----------
+        instances : DataType
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Iterable[tuple[DataType, DataType]]
+            Iterable of ``(train_set, test_set)`` splits for the provided data.
         """
         raise NotImplementedError
 
@@ -619,10 +919,14 @@ def get_instances_by_category[InstanceDataType: InstanceData](
     The returned value is an iterator with each item being a tuple of the category and the subset of instances of that
     category.
 
-    :param instances: the set of instances to draw from
-    :param category_field: the name of the field in instances that indicates the categories
-    :param category_shape: the optional shape of the category field
-    :return: tuples of categories and corresponding subsets of instances
+    Parameters
+    ----------
+    instances : InstanceDataType
+        Input instances to be processed by this method.
+    category_field : str
+        Value passed via ``category_field``.
+    category_shape : tuple[int] | None
+        Value passed via ``category_shape``.
     """
     # extract the category values from the instances
     if not hasattr(instances, category_field):

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -486,7 +486,6 @@ class LLRData(FeatureData):
     - llr_intervals: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals
     - llr_upper_bound: upper bound applied to the LLRs, or `None` if no upper bound was applied
     - llr_lower_bound: lower bound applied to the LLRs, or `None` if no lower bound was applied
-
     """
 
     llr_upper_bound: float | None = None

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -65,7 +65,8 @@ class InstanceData(BaseModel, ABC):
     This class imposes no restrictions on the actual instance data. Sub class implementations will specialize in
     particular data types.
 
-    Attributes:
+    Attributes
+    ----------
     - `labels`: The hypothesis labels of the instances, as a 1-dimensional array with one value per instance, can be
       either 0 or 1.
     - `source_ids`: The ids of all sources that contributed to the instances. Each instance is from a single source,
@@ -362,7 +363,8 @@ class FeatureData(InstanceData):
 
     More than 2 dimensions may be used for paired data, see `PairedFeatureData`.
 
-    Attributes:
+    Attributes
+    ----------
     - features: an array of instance features, with one row per instance
     """
 
@@ -408,7 +410,8 @@ class PairedFeatureData(FeatureData):
 
     The `source_ids`, if available, must have two values for each item, i.e. 2 columns.
 
-    Attributes:
+    Attributes
+    ----------
     - n_trace_instances: the number of trace instances in each pair
     - n_ref_instances: the number of reference instances in each pair
     - features: the features of all instances in the pair, with pairs along the first dimension, and instances along the
@@ -476,7 +479,8 @@ class LLRData(FeatureData):
 
     The values are also accessible by the attributes `llrs` and `llr_intervals`.
 
-    Attributes:
+    Attributes
+    ----------
     - llrs: 1-dimensional numpy array of LLR values
     - has_intervals: indicate whether the LLR's have intervals
     - llr_intervals: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals

--- a/lir/data/models.py
+++ b/lir/data/models.py
@@ -99,7 +99,7 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def source_ids_1d(self) -> np.ndarray:
-        """:return: the attribute `source_ids` as a 1-dimensional array, with one source id per instance"""
+        """:return: the attribute `source_ids` as a 1-dimensional array, with one source id per instance."""
         if self.source_ids is None:
             raise ValueError('source_ids not available')
         if len(self.source_ids.shape) != 1:
@@ -108,7 +108,7 @@ class InstanceData(BaseModel, ABC):
 
     @abstractmethod
     def __len__(self) -> int:
-        """:return: the number of instances in this dataset"""
+        """:return: the number of instances in this dataset."""
         raise NotImplementedError
 
     def __getitem__(self, indexes: np.ndarray | int) -> Self:
@@ -309,7 +309,7 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def all_fields(self) -> list[str]:
-        """:return: a list of all fields, including both mandatory and extra fields"""
+        """:return: a list of all fields, including both mandatory and extra fields."""
         all_fields = list(type(self).model_fields.keys())
         if self.model_extra:
             all_fields += list(self.model_extra.keys())
@@ -317,7 +317,7 @@ class InstanceData(BaseModel, ABC):
 
     @property
     def has_labels(self) -> bool:
-        """:return: True iff the instances are labeled"""
+        """:return: True iff the instances are labeled."""
         return self.labels is not None
 
     def replace(self, **kwargs: Any) -> Self:
@@ -493,7 +493,7 @@ class LLRData(FeatureData):
 
     @property
     def llrs(self) -> np.ndarray:
-        """:return: 1-dimensional numpy array of LLR values"""
+        """:return: 1-dimensional numpy array of LLR values."""
         if len(self.features.shape) == 1:
             return self.features
         else:
@@ -501,12 +501,12 @@ class LLRData(FeatureData):
 
     @property
     def has_intervals(self) -> bool:
-        """:return: indicate whether the LLR's have intervals"""
+        """:return: indicate whether the LLR's have intervals."""
         return len(self.features.shape) == 2 and self.features.shape[1] == 3
 
     @property
     def llr_intervals(self) -> np.ndarray | None:
-        """:return: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals"""
+        """:return: numpy array of LLR values of dimensions (n, 2), or `None` if the LLR's have no intervals."""
         if self.has_intervals:
             return self.features[:, 1:]
         else:
@@ -514,7 +514,7 @@ class LLRData(FeatureData):
 
     @property
     def llr_bounds(self) -> tuple[float | None, float | None]:
-        """:return: a tuple (min_llr, max_llr)"""
+        """:return: a tuple (min_llr, max_llr)."""
         return self.llr_lower_bound, self.llr_upper_bound
 
     @model_validator(mode='after')

--- a/lir/data_strategies.py
+++ b/lir/data_strategies.py
@@ -31,15 +31,29 @@ class TrainTestSplit(DataStrategy):
           strategy: train_test
           test_size: 0.2  # the (hold-out) test set  is 20% of the data
           seed: 42  # optional
+
+    Parameters
+    ----------
+    test_size : float | int
+        Size of the test set. If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to
+        include in the test split. If int, represents the absolute number of test samples.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(self, test_size: float | int, seed: int | None = None):
         """
         Initialize the object.
 
-        :param test_size: If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include
             in the test split. If int, represents the absolute number of test samples.
-        :param seed: The random state.
+
+        Parameters
+        ----------
+        test_size : float | int
+            Size of the test set. If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to
+            include in the test split. If int, represents the absolute number of test samples.
+        seed : int | None
+            Random seed controlling stochastic behaviour for reproducible results.
         """
         self.test_size = test_size
         self.seed = seed
@@ -47,6 +61,11 @@ class TrainTestSplit(DataStrategy):
     def apply[DataType: InstanceData](self, instances: DataType) -> Iterator[tuple[DataType, DataType]]:
         """
         Split the data into a training set and a test set.
+
+        Parameters
+        ----------
+        instances : DataType
+            Instances to split.
 
         Yields
         ------
@@ -76,21 +95,39 @@ class CrossValidation(DataStrategy):
           strategy: cross_validation
           folds: 5  # the number k in k-fold cross-validation
           seed: 42  # optional
+
+    Parameters
+    ----------
+    folds : int
+        Number of cross-validation folds to generate.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(self, folds: int, seed: int | None = None):
         """
-        Initialize the object.
+        Initialize the object for K-fold cross-validation.
 
-        :param folds: The number of train/test splits to return.
-        :param seed: The random state.
+        Parameters
+        ----------
+        folds : int
+            Number of cross-validation folds to generate.
+        seed : int | None
+            Random seed controlling stochastic behaviour for reproducible results.
         """
         self.folds = folds
         self.seed = seed
         self.shuffle = True if self.seed is not None else False  # noqa: SIM210
 
     def apply(self, instances: InstanceDataType) -> Iterator[tuple[InstanceDataType, InstanceDataType]]:
-        """Return an iterator over *k* train/test splits."""
+        """
+        Return an iterator over *k* train/test splits.
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
+        """
         kf = KFold(n_splits=self.folds, shuffle=self.shuffle, random_state=self.seed)
         for train_index, test_index in kf.split(np.arange(len(instances)), y=instances.labels):
             yield instances[train_index], instances[test_index]
@@ -117,6 +154,13 @@ class SourcesTrainTestSplit(DataStrategy):
           seed: 42        # optional
 
     This class internally uses ``sklearn.model_selection.GroupShuffleSplit``.
+
+    Parameters
+    ----------
+    test_size : float | int
+        Fraction or absolute number of items assigned to the test split.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(self, test_size: float | int, seed: int | None = None):
@@ -125,7 +169,13 @@ class SourcesTrainTestSplit(DataStrategy):
 
         :param test_size: If float, should be between 0.0 and 1.0 and represent the proportion of sources to include in
             the test split (rounded up). If int, represents the absolute number of test sources.
-        :param seed: The random state.
+
+        Parameters
+        ----------
+        test_size : float | int
+            Fraction or absolute number of items assigned to the test split.
+        seed : int | None
+            Random seed controlling stochastic behaviour for reproducible results.
         """
         self.test_size = test_size
         self.seed = seed
@@ -133,6 +183,11 @@ class SourcesTrainTestSplit(DataStrategy):
     def apply(self, instances: InstanceDataType) -> Iterator[tuple[InstanceDataType, InstanceDataType]]:
         """
         Split the data into a training set and a test set.
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
 
         Yields
         ------
@@ -162,10 +217,14 @@ class SourcesCrossValidation(DataStrategy):
           folds: 5
 
     This class internally uses ``sklearn.model_selection.GroupKFold``.
+
+    Parameters
+    ----------
+    folds : int
+        Number of cross-validation folds to generate.
     """
 
     def __init__(self, folds: int):
-        """:param folds: the number of train/test splits to return."""
         self.folds = folds
 
     def apply(self, instances: InstanceDataType) -> Iterator[tuple[InstanceDataType, InstanceDataType]]:
@@ -173,6 +232,11 @@ class SourcesCrossValidation(DataStrategy):
         Perform *k*-fold cross-validation.
 
         Return an iterator over *k* train/test splits.
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
         """
         kf = GroupKFold(n_splits=self.folds)
 
@@ -181,19 +245,31 @@ class SourcesCrossValidation(DataStrategy):
 
 
 class PairsTrainTestSplit(DataStrategy):
-    """A train/test split policy for paired instances.
+    """
+    A train/test split policy for paired instances.
 
     The input data should have ``source_ids`` with two columns. This split assigns all sources to either the training
     set or the test set. The pairs are assigned to training or testing if both of their sources have that role. Pairs
     with mixed roles are omitted.
+
+    Parameters
+    ----------
+    test_size : float | int
+        Fraction or absolute number of items assigned to the test split.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(self, test_size: float | int, seed: int | None = None):
         """
         Initialize the object.
 
-        :param test_size: The proportion of sources to include in the test set.
-        :param seed: The random state.
+        Parameters
+        ----------
+        test_size : float | int
+            Fraction or absolute number of items assigned to the test split.
+        seed : int | None
+            Random seed controlling stochastic behaviour for reproducible results.
         """
         self.test_size = test_size
         self.seed = seed
@@ -201,6 +277,11 @@ class PairsTrainTestSplit(DataStrategy):
     def apply(self, instances: InstanceDataType) -> Iterator[tuple[InstanceDataType, InstanceDataType]]:
         """
         Split the data into a training set and a test set.
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
 
         Yields
         ------
@@ -253,6 +334,11 @@ class PredefinedTrainTestSplit(DataStrategy):
         """
         Split the data into a training set and a test set.
 
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
+
         Yields
         ------
         tuple[DataType, DataType]
@@ -293,7 +379,10 @@ class PredefinedCrossValidation(DataStrategy):
         identifier. The strategy will return one train/test split for each unique fold identifier, using the instances
         with that identifier as the test set and the others as the training set.
 
-        :return: an iterator over train/test splits.
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
         """
         if 'fold_assignments' not in instances.all_fields:
             raise ValueError('`fold_assignments` field is missing')

--- a/lir/data_strategies.py
+++ b/lir/data_strategies.py
@@ -31,7 +31,6 @@ class TrainTestSplit(DataStrategy):
           strategy: train_test
           test_size: 0.2  # the (hold-out) test set  is 20% of the data
           seed: 42  # optional
-
     """
 
     def __init__(self, test_size: float | int, seed: int | None = None):
@@ -77,7 +76,6 @@ class CrossValidation(DataStrategy):
           strategy: cross_validation
           folds: 5  # the number k in k-fold cross-validation
           seed: 42  # optional
-
     """
 
     def __init__(self, folds: int, seed: int | None = None):

--- a/lir/data_strategies.py
+++ b/lir/data_strategies.py
@@ -49,7 +49,10 @@ class TrainTestSplit(DataStrategy):
         """
         Split the data into a training set and a test set.
 
-        :return: an iterator over a single item, which is a tuple of the training set and the test set.
+        Yields
+        ------
+        tuple[DataType, DataType]
+            An iterator over a single item, which is a tuple of the training set and the test set.
         """
         indexes = np.arange(len(instances))
         indexes_train, indexes_test = sklearn.model_selection.train_test_split(
@@ -133,7 +136,10 @@ class SourcesTrainTestSplit(DataStrategy):
         """
         Split the data into a training set and a test set.
 
-        :return: an iterator over a single item, which is a tuple of the training set and the test set.
+        Yields
+        ------
+        tuple[DataType, DataType]
+            An iterator over a single item, which is a tuple of the training set and the test set.
         """
         splitter = GroupShuffleSplit(test_size=self.test_size, n_splits=1, random_state=self.seed)
         ((train_index, test_index),) = splitter.split(np.arange(len(instances)), groups=instances.source_ids_1d)
@@ -198,7 +204,10 @@ class PairsTrainTestSplit(DataStrategy):
         """
         Split the data into a training set and a test set.
 
-        :return: an iterator over a single item, which is a tuple of the training set and the test set.
+        Yields
+        ------
+        tuple[DataType, DataType]
+            An iterator over a single item, which is a tuple of the training set and the test set.
         """
         source_ids = instances.source_ids
         if source_ids is None or len(source_ids.shape) != 2 or source_ids.shape[1] != 2:
@@ -246,7 +255,10 @@ class PredefinedTrainTestSplit(DataStrategy):
         """
         Split the data into a training set and a test set.
 
-        :return: an iterator over a single item, which is a tuple of the training set and the test set.
+        Yields
+        ------
+        tuple[DataType, DataType]
+            An iterator over a single item, which is a tuple of the training set and the test set.
         """
         if 'role_assignments' not in instances.all_fields:
             raise ValueError('`role_assignments` field is missing')

--- a/lir/data_strategies.py
+++ b/lir/data_strategies.py
@@ -165,7 +165,7 @@ class SourcesCrossValidation(DataStrategy):
     """
 
     def __init__(self, folds: int):
-        """:param folds: the number of train/test splits to return"""
+        """:param folds: the number of train/test splits to return."""
         self.folds = folds
 
     def apply(self, instances: InstanceDataType) -> Iterator[tuple[InstanceDataType, InstanceDataType]]:

--- a/lir/datasets/alcohol_breath_analyser.py
+++ b/lir/datasets/alcohol_breath_analyser.py
@@ -4,20 +4,33 @@ from lir.data.models import DataProvider, LLRData
 
 
 class AlcoholBreathAnalyser(DataProvider):
-    """Alcohol Breath Analyser example class.
+    """
+    Alcohol Breath Analyser example class.
 
     Example from paper:
         Peter Vergeer, Andrew van Es, Arent de Jongh, Ivo Alberink and Reinoud
         Stoel, Numerical likelihood ratios outputted by LR systems are often
         based on extrapolation: When to stop extrapolating? In: Science and
         Justice 56 (2016) 482–491.
+
+    Parameters
+    ----------
+    ill_calibrated : bool
+        Whether to load the intentionally ill-calibrated variant of the dataset.
     """
 
     def __init__(self, ill_calibrated: bool = False):
         self.ill_calibrated = ill_calibrated
 
     def get_instances(self) -> LLRData:
-        """Provide LLR data for example system."""
+        """
+        Provide LLR data for example system.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
+        """
         positive_lr = 1000 if self.ill_calibrated else 90
         lrs = np.concatenate(
             [

--- a/lir/datasets/feature_data_csv.py
+++ b/lir/datasets/feature_data_csv.py
@@ -60,8 +60,8 @@ class FeatureDataCsvParser(DataProvider, ABC):
     - :class:`FeatureDataCsvStreamParser` for reading from a stream.
 
 
-    Example
-    -------
+    Examples
+    --------
     Assume a CSV file containing two features and source identifiers:
 
     .. code-block:: text

--- a/lir/datasets/feature_data_csv.py
+++ b/lir/datasets/feature_data_csv.py
@@ -36,8 +36,15 @@ class ExtraField(NamedTuple):
         """
         Take the appropriate values from a dictionary and return them as a list.
 
-        :param row: the CSV line as a dictionary.
-        :return: a list of values.
+        Parameters
+        ----------
+        row : dict[str, str]
+            CSV row dictionary to parse.
+
+        Returns
+        -------
+        list[Any]
+            Parsed values extracted from the input row.
         """
         values = []
         for colname in self.column_names:
@@ -58,6 +65,27 @@ class FeatureDataCsvParser(DataProvider, ABC):
     - :class:`FeatureDataCsvFileParser` for reading from a local file;
     - :class:`FeatureDataCsvHttpParser` for reading from a URL;
     - :class:`FeatureDataCsvStreamParser` for reading from a stream.
+
+    Parameters
+    ----------
+    source_id_column : str | list[str] | None
+        Column name(s) containing source identifiers.
+    label_column : str | None
+        Column name containing class labels.
+    instance_id_column : str | None
+        Column name containing instance identifiers.
+    role_assignment_column : str | None
+        Column name containing predefined train/test roles.
+    fold_assignment_column : str | None
+        Column name containing predefined fold assignments.
+    extra_fields : list[ExtraField] | None
+        Optional extra fields to parse from each row.
+    ignore_columns : list[str] | None
+        Column names ignored when extracting features.
+    head : int | None
+        Maximum number of rows to read from the source.
+    message_prefix : str
+        Prefix added to parser log and error messages.
 
     Examples
     --------
@@ -103,15 +131,26 @@ class FeatureDataCsvParser(DataProvider, ABC):
         Special columns can be assigned as such or can be ignored (see below). All other columns are interpreted as
         feature columns. All arguments are optional.
 
-        :param source_id_column: the name (or list of two names) of the column that has the source ids
-        :param label_column: the name of the column that contains the hypothesis label (0 or 1)
-        :param instance_id_column: the name of the column that contains the instance id (str)
-        :param role_assignment_column: the name of the column that contains the role assignment ("train" or "test")
-        :param fold_assignment_column: the name of the column that contains the fold assignment (Any)
-        :param extra_fields: extra fields to read, in addition to the above
-        :param ignore_columns: the names of the columns that should be ignored
-        :param head: read at most this number of rows from the file only, and ignore all others
-        :param message_prefix: a string to prefix to all log and error messages
+        Parameters
+        ----------
+        source_id_column : str | list[str] | None
+            Column name(s) containing source identifiers.
+        label_column : str | None
+            Column name containing class labels.
+        instance_id_column : str | None
+            Column name containing instance identifiers.
+        role_assignment_column : str | None
+            Column name containing predefined train/test roles.
+        fold_assignment_column : str | None
+            Column name containing predefined fold assignments.
+        extra_fields : list[ExtraField] | None
+            Optional extra fields to parse from each row.
+        ignore_columns : list[str] | None
+            Column names ignored when extracting features.
+        head : int | None
+            Maximum number of rows to read from the source.
+        message_prefix : str
+            Prefix added to parser log and error messages.
         """
         self.source_id_columns: list[str] = (
             [source_id_column] if isinstance(source_id_column, str) else source_id_column or []
@@ -237,20 +276,40 @@ class FeatureDataCsvParser(DataProvider, ABC):
 
 
 class FeatureDataCsvFileParser(FeatureDataCsvParser):
-    """Read CSV data from file."""
+    """
+    Read CSV data from file.
+
+    Parameters
+    ----------
+    file : PathLike
+        Path to the input file.
+    **kwargs : Any
+        Additional keyword arguments forwarded to the underlying call.
+    """
 
     def __init__(self, file: PathLike, **kwargs: Any):
         """
         Initialize the CSV parser that reads data from a file.
 
-        :param file: the path to the csv file
-        :param kwargs: arguments passed to FeatureDataCsvParser
+        Parameters
+        ----------
+        file : PathLike
+            Path to the input file.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
         """
         super().__init__(**kwargs, message_prefix=f'{file}: ')
         self.path = Path(file)
 
     def get_instances(self) -> FeatureData:
-        """Retrieve FeatureData instances."""
+        """
+        Retrieve FeatureData instances.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         path = search_path(self.path)
         LOG.debug(f'parsing CSV file: {self.path} as {path}')
         with open(path) as f:
@@ -258,26 +317,57 @@ class FeatureDataCsvFileParser(FeatureDataCsvParser):
 
 
 class FeatureDataCsvStreamParser(FeatureDataCsvParser):
-    """Read data from a streamed CSV."""
+    """
+    Read data from a streamed CSV.
+
+    Parameters
+    ----------
+    fp : IO
+        Open file-like object to read from.
+    **kwargs : Any
+        Additional keyword arguments forwarded to the underlying call.
+    """
 
     def __init__(self, fp: IO, **kwargs: Any):
         """
         Initialize the CSV parser that reads data from a stream.
 
-        :param flo: the file-like object
-        :param kwargs: arguments passed to FeatureDataCsvParser
+        Parameters
+        ----------
+        fp : IO
+            Open file-like object to read from.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
         """
         super().__init__(**kwargs)
         self.fp = fp
 
     def get_instances(self) -> FeatureData:
-        """Retrieve FeatureData instances from CSV stream."""
+        """
+        Retrieve FeatureData instances from CSV stream.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         LOG.debug('parsing CSV stream')
         return self._parse_file(self.fp)
 
 
 class FeatureDataCsvHttpParser(FeatureDataCsvParser):
-    """Read CSV data from a URL."""
+    """
+    Read CSV data from a URL.
+
+    Parameters
+    ----------
+    url : str
+        URL of the remote resource to read.
+    session : requests.Session
+        Value passed via ``session``.
+    **kwargs : Any
+        Additional keyword arguments forwarded to the underlying call.
+    """
 
     def __init__(self, url: str, session: requests.Session, **kwargs: Any):
         """
@@ -286,16 +376,28 @@ class FeatureDataCsvHttpParser(FeatureDataCsvParser):
         By default, this class uses `requests-cache` to cache retrieved data. The cache is persistent and located in
         the user cache folder, which is written to the log file.
 
-        :param url: the URL to the CSV resource
-        :param session: requests session for HTTP requests
-        :param kwargs: arguments passed to FeatureDataCsvParser
+        Parameters
+        ----------
+        url : str
+            URL of the remote resource to read.
+        session : requests.Session
+            Value passed via ``session``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying call.
         """
         super().__init__(**kwargs, message_prefix=url)
         self.url = url
         self.session = session
 
     def get_instances(self) -> FeatureData:
-        """Retrieve FeatureData from the remote resource."""
+        """
+        Retrieve FeatureData from the remote resource.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         LOG.debug(f'parsing CSV from URL: {self.url}')
         response = self.session.get(self.url, stream=True)
         fp = io.StringIO(response.text)
@@ -340,6 +442,18 @@ def feature_data_csv_http_parser(config: ContextAwareDict, output_dir: Path) -> 
         - use_cache: boolean indicating whether to cache retrieved data
 
     Other arguments are passed directly to `FeatureDataCsvParser`.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    output_dir : Path
+        Directory where generated outputs are written.
+
+    Returns
+    -------
+    FeatureDataCsvHttpParser
+        FeatureData object parsed from the source.
     """
     use_cache = pop_field(config, 'use_cache', default=True, validate=partial(check_type, bool))
 
@@ -355,5 +469,19 @@ def feature_data_csv_http_parser(config: ContextAwareDict, output_dir: Path) -> 
 
 @config_parser
 def feature_data_csv_file_parser(config: ContextAwareDict, output_dir: Path) -> FeatureDataCsvFileParser:
-    """Initialize the CSV parser that reads data from a stream."""
+    """
+    Initialize the CSV parser that reads data from a stream.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    output_dir : Path
+        Directory where generated outputs are written.
+
+    Returns
+    -------
+    FeatureDataCsvFileParser
+        FeatureData object parsed from the source.
+    """
     return _parse_feature_data_csv(FeatureDataCsvFileParser, config)

--- a/lir/datasets/feature_data_csv.py
+++ b/lir/datasets/feature_data_csv.py
@@ -59,7 +59,6 @@ class FeatureDataCsvParser(DataProvider, ABC):
     - :class:`FeatureDataCsvHttpParser` for reading from a URL;
     - :class:`FeatureDataCsvStreamParser` for reading from a stream.
 
-
     Examples
     --------
     Assume a CSV file containing two features and source identifiers:

--- a/lir/datasets/glass.py
+++ b/lir/datasets/glass.py
@@ -20,6 +20,11 @@ class GlassData(DataProvider):
     set of five instances per source.
 
     Data are retrieved from the web as needed and stored locally for later use.
+
+    Parameters
+    ----------
+    cache_dir : PathLike
+        Cache directory used for storing downloaded dataset files.
     """
 
     def __init__(self, cache_dir: PathLike):
@@ -29,7 +34,21 @@ class GlassData(DataProvider):
         )
 
     def _load_data(self, file: str, role: RoleAssignment) -> FeatureData:
-        """Return a tuple of features, source_ids and instance_ids."""
+        """
+        Return a tuple of features, source_ids and instance_ids.
+
+        Parameters
+        ----------
+        file : str
+            Path to the input file.
+        role : RoleAssignment
+            Role label assigned to rows in this split.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         source_ids = []
         instance_ids = []
         values = []
@@ -73,6 +92,11 @@ class GlassData(DataProvider):
         - source_ids: a 1d array of source ids (str)
         - instance_ids: a 1d array of unique instance ids (str)
         - role_assignments: a 1d array of role assignments (values "train" or "test")
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
         """
         training_data = self._load_data('training.csv', RoleAssignment.TRAIN)
         duplo = self._load_data('duplo.csv', RoleAssignment.TEST)

--- a/lir/datasets/synthesized_normal_binary.py
+++ b/lir/datasets/synthesized_normal_binary.py
@@ -8,11 +8,21 @@ from lir.data.models import DataProvider, FeatureData
 
 
 class SynthesizedNormalData:
-    """Representation of normally distributed data, leveraging a number generator.
+    """
+    Representation of normally distributed data, leveraging a number generator.
 
     The generated data can be used to generate normally distributed data and is useful
     for debugging purposes or gaining insight in the effect of varying parts within the
     LR system pipeline.
+
+    Parameters
+    ----------
+    mean : float
+        Mean value of the generated normal distribution.
+    std : float
+        Standard deviation of the generated normal distribution.
+    size : int | tuple[int, int]
+        Number of samples to generate.
     """
 
     def __init__(self, mean: float, std: float, size: int | tuple[int, int]):
@@ -22,12 +32,35 @@ class SynthesizedNormalData:
         self.size = (size, 1) if isinstance(size, int) else size
 
     def get(self, rng: numpy.random.Generator) -> np.ndarray:
-        """Draw random samples from a normally distributed data set."""
+        """
+        Draw random samples from a normally distributed data set.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator
+            Random number generator used for sampling.
+
+        Returns
+        -------
+        np.ndarray
+            Randomly sampled values for this distribution configuration.
+        """
         return rng.normal(loc=self.mean, scale=self.std, size=self.size)
 
 
 class SynthesizedNormalBinaryData(DataProvider):
-    """Implementation of a data source generating normally distributed binary class data."""
+    """
+    Implementation of a data source generating normally distributed binary class data.
+
+    Parameters
+    ----------
+    h1_params : SynthesizedNormalData
+        Distribution parameters used to sample class-1 data.
+    h2_params : SynthesizedNormalData
+        Distribution parameters used to sample class-2 data.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
+    """
 
     def __init__(self, h1_params: SynthesizedNormalData, h2_params: SynthesizedNormalData, seed: int | None = None):
         self.data_parameters = [h1_params, h2_params]
@@ -38,6 +71,11 @@ class SynthesizedNormalBinaryData(DataProvider):
         Return instances with randomly synthesized data and binary labels.
 
         The features are drawn from a normal distribution, as configured.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
         """
         rng = np.random.default_rng(seed=self.seed)
         features = np.concatenate([data_class.get(rng) for data_class in self.data_parameters])
@@ -47,7 +85,21 @@ class SynthesizedNormalBinaryData(DataProvider):
 
 @config_parser
 def synthesized_normal_binary(config: ContextAwareDict, _: Path) -> SynthesizedNormalBinaryData:
-    """Set up (binary class) data source class to obtain normally distributed data from configuration."""
+    """
+    Set up (binary class) data source class to obtain normally distributed data from configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    _ : Path
+        Unused argument required by the parser interface.
+
+    Returns
+    -------
+    SynthesizedNormalBinaryData
+        Configured binary synthesized data provider.
+    """
     seed = pop_field(config, 'seed', required=False)
     h1 = pop_field(config, 'h1')
     h2 = pop_field(config, 'h2')

--- a/lir/datasets/synthesized_normal_multiclass.py
+++ b/lir/datasets/synthesized_normal_multiclass.py
@@ -17,7 +17,20 @@ class SynthesizedDimension(NamedTuple):
 
 
 class SynthesizedNormalMulticlassData(DataProvider):
-    """Implementation of a data source generating normally distributed multiclass data."""
+    """
+    Implementation of a data source generating normally distributed multiclass data.
+
+    Parameters
+    ----------
+    dimensions : list[SynthesizedDimension]
+        Number of feature dimensions to include in the header.
+    population_size : int
+        Number of sources to sample in the synthetic population.
+    sources_size : int
+        Number of source groups represented in the dataset.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
+    """
 
     def __init__(
         self,
@@ -50,6 +63,11 @@ class SynthesizedNormalMulticlassData(DataProvider):
         Return instances with randomly synthesized data and multi-class labels.
 
         The features are drawn from a normal distribution, as configured.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
         """
         rng = np.random.default_rng(seed=self.seed)
 
@@ -62,7 +80,21 @@ class SynthesizedNormalMulticlassData(DataProvider):
 
 @config_parser
 def synthesized_normal_multiclass(config: ContextAwareDict, _: Path) -> SynthesizedNormalMulticlassData:
-    """Set up (multiple class) data source class to obtain normally distributed data from configuration."""
+    """
+    Set up (multiple class) data source class to obtain normally distributed data from configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    _ : Path
+        Unused argument required by the parser interface.
+
+    Returns
+    -------
+    SynthesizedNormalMulticlassData
+        Configured multiclass synthesized data provider.
+    """
     seed = pop_field(config, 'seed', validate=int, required=False)
 
     population = pop_field(config, 'population')

--- a/lir/experiments/base_experiment.py
+++ b/lir/experiments/base_experiment.py
@@ -15,7 +15,18 @@ from lir.lrsystems.lrsystems import LRSystem
 
 
 class Experiment(ABC):
-    """Representation of an experiment pipeline run for each provided LR system."""
+    """
+    Representation of an experiment pipeline run for each provided LR system.
+
+    Parameters
+    ----------
+    name : str
+        Name used to identify this object in outputs and logs.
+    outputs : Sequence[Aggregation]
+        Output aggregation definitions executed after each run.
+    output_path : Path
+        Path where generated outputs are written.
+    """
 
     def __init__(
         self,
@@ -35,7 +46,8 @@ class Experiment(ABC):
         run_name: str,
         data_config: ContextAwareDict,
     ) -> LLRData:
-        """Run experiment on a single LR system configuration using the provided data.
+        """
+        Run experiment on a single LR system configuration using the provided data.
 
         The LR system is fitted using the training subset data and
         subsequently used to determine LLRs for the test subset data. The results are stored in
@@ -47,6 +59,24 @@ class Experiment(ABC):
 
         Next to this, the configuration of both the data and LR system are stored in the output
         directory for future reference.
+
+        Parameters
+        ----------
+        lrsystem_config : ContextAwareDict
+            LR-system configuration for a single run.
+        split_data : Iterable[tuple[InstanceData, InstanceData]]
+            Train/test split produced by the selected data strategy.
+        parameters : dict[str, Any]
+            Parameter substitutions applied for this run.
+        run_name : str
+            Name of the current run used in result bookkeeping.
+        data_config : ContextAwareDict
+            Data configuration used to construct datasets for runs.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
         """
         run_output_dir = self.output_path / run_name
         run_output_dir.mkdir(exist_ok=True, parents=True)
@@ -113,7 +143,8 @@ class Experiment(ABC):
         raise NotImplementedError
 
     def run(self) -> None:
-        """Run experiment the configured experiment(s).
+        """
+        Run experiment the configured experiment(s).
 
         This method ensures that all outputs are properly closed after the experiment run.
         """

--- a/lir/experiments/optuna_experiment.py
+++ b/lir/experiments/optuna_experiment.py
@@ -19,7 +19,28 @@ from lir.experiments import Experiment
 
 
 class OptunaExperiment(Experiment):
-    """Representation of an experiment run for each provided LR system."""
+    """
+    Representation of an experiment run for each provided LR system.
+
+    Parameters
+    ----------
+    name : str
+        Name used to identify this object in outputs and logs.
+    data_config : ContextAwareDict
+        Data configuration used to construct datasets for runs.
+    outputs : Sequence[Aggregation]
+        Output aggregation definitions executed after each run.
+    output_path : Path
+        Path where generated outputs are written.
+    baseline_config : ContextAwareDict
+        Baseline configuration to be tuned during optimisation.
+    hyperparameters : list[Hyperparameter]
+        Hyperparameters varied during optimisation.
+    n_trials : int
+        Number of optimisation trials to execute.
+    metric_function : Callable[[LLRData], float]
+        Value passed via ``metric_function``.
+    """
 
     def __init__(
         self,

--- a/lir/experiments/predefined_experiment.py
+++ b/lir/experiments/predefined_experiment.py
@@ -13,7 +13,22 @@ from lir.experiments import Experiment
 
 
 class PredefinedExperiment(Experiment):
-    """Representation of an experiment run for each provided LR system."""
+    """
+    Representation of an experiment run for each provided LR system.
+
+    Parameters
+    ----------
+    name : str
+        Name used to identify this object in outputs and logs.
+    data_configs : list[tuple[ContextAwareDict, dict[str, Any]]]
+        Data configurations evaluated by this experiment.
+    outputs : Sequence[Aggregation]
+        Output aggregation definitions executed after each run.
+    output_path : Path
+        Path where generated outputs are written.
+    lrsystem_configs : list[tuple[ContextAwareDict, dict[str, Any]]]
+        LR-system configurations evaluated by this experiment.
+    """
 
     def __init__(
         self,

--- a/lir/lrsystems/binary_lrsystem.py
+++ b/lir/lrsystems/binary_lrsystem.py
@@ -14,24 +14,52 @@ class BinaryLRSystem(LRSystem):
     In this strategy, a set of instances - captured within the
     feature vector X - and a set of (ground-truth) labels are used to train and
     afterward calculate corresponding LLR's for given feature vectors.
+
+    Parameters
+    ----------
+    pipeline : Transformer
+        Transformer pipeline used to fit and score instances.
     """
 
     def __init__(self, pipeline: Transformer):
         self.pipeline = pipeline
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the given instance data."""
+        """
+        Fit the model on the given instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This LR system instance after fitting the pipeline.
+        """
         self.pipeline.fit(instances)
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Use LR system to calculate the LLR data from the instance data.
+        """
+        Use LR system to calculate the LLR data from the instance data.
 
         Applies the specific source LR system on a set of instances, optionally with corresponding labels, and returns a
         representation of the calculated LLR data through the `LLRData` tuple.
 
         The returned set of LLRs has the same order as the set of input instances, and the returned labels are unchanged
         from the input labels.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
         """
         llrs = self.pipeline.apply(instances)
         return LLRData(**llrs.model_dump())

--- a/lir/lrsystems/lrsystems.py
+++ b/lir/lrsystems/lrsystems.py
@@ -9,17 +9,39 @@ class LRSystem(Transformer, ABC):
     """General representation of an LR system."""
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the LR system on a set of features and corresponding labels.
+        """
+        Fit the LR system on a set of features and corresponding labels.
 
         The number of labels must be equal to the number of instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This LR system instance after optional fitting.
         """
         return self
 
     @abstractmethod
     def apply(self, instances: InstanceData) -> LLRData:
-        """Use the LR system to calculate the LLR data from the instances.
+        """
+        Use the LR system to calculate the LLR data from the instances.
 
         Applies the LR system on a set of instances, optionally with corresponding labels, and returns a
         representation of the calculated LLR data through the `LLRData` tuple.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
         """
         raise NotImplementedError

--- a/lir/lrsystems/score_based.py
+++ b/lir/lrsystems/score_based.py
@@ -8,12 +8,22 @@ from lir.transform.pipeline import Pipeline
 
 
 class ScoreBasedSystem(LRSystem):
-    """Provide a representation of a common source, score-based LR system.
+    """
+    Provide a representation of a common source, score-based LR system.
 
     In this strategy, it is possible to prepare the data within
     a `preprocessing_pipeline`, create corresponding pairs of instances using
     the `pairing_function` and subsequently calculate scores as well as transform
     these scores to LLR's in the final `evaluation_pipeline`.
+
+    Parameters
+    ----------
+    preprocessing_pipeline : Transformer | None
+        Pipeline that preprocesses instances before pairing and evaluation.
+    pairing_function : PairingMethod
+        Pairing method used to construct trace/reference comparisons.
+    evaluation_pipeline : Transformer | None
+        Pipeline that converts scores to likelihood-ratio outputs.
     """
 
     def __init__(
@@ -27,20 +37,43 @@ class ScoreBasedSystem(LRSystem):
         self.evaluation_pipeline = evaluation_pipeline or Pipeline([])
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the instance data."""
+        """
+        Fit the model on the instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This LR system instance after fitting the evaluation pipeline.
+        """
         instances = self.preprocessing_pipeline.fit_apply(instances)
         pairs = self.pairing_function.pair(instances, 1, 1)
         self.evaluation_pipeline.fit(pairs)
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Use LR system to calculate LLR data from the instances.
+        """
+        Use LR system to calculate LLR data from the instances.
 
         Applies the score-based LR system on a set of instances, optionally with corresponding labels, and returns a
         representation of the calculated LLR data through the `LLRData` tuple.
 
         The system takes instances as input, and calculates LLRs for pairs of instances. That means that there is a 2-1
         relation between input and output data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
         """
         instances = self.preprocessing_pipeline.apply(instances)
         pairs = self.pairing_function.pair(instances, 1, 1)

--- a/lir/lrsystems/two_level.py
+++ b/lir/lrsystems/two_level.py
@@ -58,13 +58,26 @@ class TwoLevelModelNormalKDE:
         self.between_covars: np.ndarray | None = None
 
     def fit_on_unpaired_instances(self, X: np.ndarray, y: np.ndarray) -> 'TwoLevelModelNormalKDE':
-        """Fit the model on unpaired instances.
+        """
+        Fit the model on unpaired instances.
 
         X np.ndarray of measurements, rows are sources/repetitions, columns are features
         y np 1d-array of labels. For each source a unique identifier (label). Repetitions get the same label.
 
         Construct the necessary matrices/scores/etc based on test data (X) so that we can predict a score later on.
         Store any calculated parameters in `self`.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Value passed via ``X``.
+        y : np.ndarray
+            Value passed via ``y``.
+
+        Returns
+        -------
+        'TwoLevelModelNormalKDE'
+            Fitted two-level KDE model instance.
         """
         assert len(X.shape) == 2, f'fit(X, y) requires X to be 2-dimensional; found dimensions {X.shape}'
         self.n_sources = self._get_n_sources(y)
@@ -78,7 +91,8 @@ class TwoLevelModelNormalKDE:
         return self
 
     def transform(self, X_trace: np.ndarray, X_ref: np.ndarray) -> np.ndarray:
-        """Transform the input data using the fitted model.
+        """
+        Transform the input data using the fitted model.
 
         Predict odds scores, making use of the parameters constructed during `self.fit()` (which should
         now be stored in `self`).
@@ -87,13 +101,26 @@ class TwoLevelModelNormalKDE:
         X_ref measurements of reference object. np.ndarray of shape (instances, repetitions_ref, features)
 
         returns: odds of same source / different source: one-dimensional np.ndarray with one element per instance
+
+        Parameters
+        ----------
+        X_trace : np.ndarray
+            Value passed via ``X_trace``.
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+
+        Returns
+        -------
+        np.ndarray
+            Log10 LR scores for each trace/reference pair.
         """
         assert self.model_fitted, 'fit() must be called before transform()'
         log10_lr_score = self._predict_log10_lr_score(X_trace, X_ref)
         return log10_lr_score
 
     def predict_proba(self, X_trace: np.ndarray, X_ref: np.ndarray) -> np.ndarray:
-        """Predict probability scores, using the fitted model.
+        """
+        Predict probability scores, using the fitted model.
 
         Predict probability scores, making use of the parameters constructed during `self.fit()` (which should
         now be stored in `self`).
@@ -102,6 +129,18 @@ class TwoLevelModelNormalKDE:
         X_ref measurements of reference object. np.ndarray of shape (instances, repetitions_ref, features)
 
         returns: probabilities for same source and different source: np.ndarray with shape (instances, 2)
+
+        Parameters
+        ----------
+        X_trace : np.ndarray
+            Value passed via ``X_trace``.
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+
+        Returns
+        -------
+        np.ndarray
+            Two-column probability matrix for Hd and Hp.
         """
         logodds_score = self.transform(X_trace, X_ref)
         p0 = 1 / (1 + 10**logodds_score)
@@ -109,7 +148,8 @@ class TwoLevelModelNormalKDE:
         return np.stack([p0, p1], axis=1)
 
     def _predict_log10_lr_score(self, X_trace: np.ndarray, X_ref: np.ndarray) -> np.ndarray:
-        """Predict natural log LR scores (ln_LR scores) using the fitted model.
+        """
+        Predict natural log LR scores (ln_LR scores) using the fitted model.
 
         Predict ln_LR scores, making use of the parameters constructed during `self.fit()` (which should
                 now be stored in `self`).
@@ -117,6 +157,18 @@ class TwoLevelModelNormalKDE:
         X_trace measurements of trace object. np.ndarray of shape (instances, repetitions_trace, features)
         X_ref measurements of reference object. np.ndarray of shape (instances, repetitions_ref, features)
         returns: log10_LR_scores according to the two_level_model in Bolck et al. np.ndarray of shape (instances,)
+
+        Parameters
+        ----------
+        X_trace : np.ndarray
+            Value passed via ``X_trace``.
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+
+        Returns
+        -------
+        np.ndarray
+            Log10 LR scores predicted for all input pairs.
         """
         if not self.model_fitted:
             raise ValueError('The model is not fitted; fit it before you use it for predicting')
@@ -165,21 +217,47 @@ class TwoLevelModelNormalKDE:
 
     @staticmethod
     def _get_n_features(X: np.ndarray, feature_ix: int = 2) -> int:
-        """Calculate the number of features in `X`."""
+        """
+        Calculate the number of features in `X`.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Value passed via ``X``.
+        feature_ix : int
+            Value passed via ``feature_ix``.
+
+        Returns
+        -------
+        int
+            Number of feature dimensions in the provided array.
+        """
         return X.shape[feature_ix]
 
     @staticmethod
     def _get_n_sources(y: np.ndarray) -> int:
-        """Calculate the number of sources in `y`.
+        """
+        Calculate the number of sources in `y`.
 
         Y np 1d-array of labels. labels from {1, ..., n} with n the number of sources. Repetitions get the same label.
         returns: number of sources in y (int).
+
+        Parameters
+        ----------
+        y : np.ndarray
+            Value passed via ``y``.
+
+        Returns
+        -------
+        int
+            Number of unique source labels.
         """
         return len(np.unique(y))
 
     @staticmethod
     def _get_mean_covariance_within(X: np.ndarray, y: np.ndarray) -> np.ndarray:
-        """Calculate a matrix of mean covariances within each of the sources.
+        """
+        Calculate a matrix of mean covariances within each of the sources.
 
         X np.array of measurements, rows are sources/repetitions, columns are features
         y np 1d-array of labels. labels from {1, ..., n} with n the number of sources. Repetitions get the same label.
@@ -187,6 +265,18 @@ class TwoLevelModelNormalKDE:
 
         This function calculates a matrix of mean covariances within each of the sources, it does so by grouping the
         data per source, calculating the covariance matrices per source and then taking the mean per feature.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Value passed via ``X``.
+        y : np.ndarray
+            Value passed via ``y``.
+
+        Returns
+        -------
+        np.ndarray
+            Mean within-source covariance matrix.
         """
         # Get unique sources
         unique_sources = np.unique(y)
@@ -215,11 +305,24 @@ class TwoLevelModelNormalKDE:
 
     @staticmethod
     def _get_means_per_source(X: np.ndarray, y: np.ndarray) -> np.ndarray:
-        """Provide numpy array of means per source.
+        """
+        Provide numpy array of means per source.
 
         X np.array of measurements, rows are sources/repetitions, columns are features
         y np 1d-array of labels. For each source a unique identifier (label). Repetitions get the same label.
         returns: means per source in a np.array matrix of size: number of sources * number of features.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Value passed via ``X``.
+        y : np.ndarray
+            Value passed via ``y``.
+
+        Returns
+        -------
+        np.ndarray
+            Matrix of per-source mean feature vectors.
         """
         # Get unique sources and calculate means for each
         unique_sources = np.unique(y)
@@ -227,10 +330,23 @@ class TwoLevelModelNormalKDE:
 
     @staticmethod
     def _get_kernel_bandwidth_squared(n_sources: int, n_features_train: int) -> float:
-        """Calculate kernel bandwidth and return it.
+        """
+        Calculate kernel bandwidth and return it.
 
         Reference: 'Density estimation for statistics and data analysis', B.W. Silverman,
             page 86 formula 4.14 with A(K) the second row in the table on page 87.
+
+        Parameters
+        ----------
+        n_sources : int
+            Value passed via ``n_sources``.
+        n_features_train : int
+            Value passed via ``n_features_train``.
+
+        Returns
+        -------
+        float
+            Squared kernel bandwidth computed with Silverman's rule.
         """
         # calculate kernel bandwidth and square it, using Silverman's rule for multivariate data
         kernel_bandwidth = (4 / ((n_features_train + 2) * n_sources)) ** (1 / (n_features_train + 4))
@@ -238,12 +354,27 @@ class TwoLevelModelNormalKDE:
 
     @staticmethod
     def _get_between_covariance(X: np.ndarray, y: np.ndarray, mean_within_covars: np.ndarray) -> np.ndarray:
-        """Calculate and return the between covariance.
+        """
+        Calculate and return the between covariance.
 
         X np.array of measurements, rows are objects, columns are variables
         y np 1d-array of labels. labels from {1, ..., n} with n the number of objects. Repetitions get the same label.
         returns: estimated covariance of true mean of the features between sources in the population in a np.array
             square matrix with number of features^2 as dimension.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Value passed via ``X``.
+        y : np.ndarray
+            Value passed via ``y``.
+        mean_within_covars : np.ndarray
+            Value passed via ``mean_within_covars``.
+
+        Returns
+        -------
+        np.ndarray
+            Estimated between-source covariance matrix.
         """
         # Get unique sources and their repetition counts
         unique_sources, counts = np.unique(y, return_counts=True)
@@ -277,7 +408,8 @@ class TwoLevelModelNormalKDE:
     def _predict_covariances_trace_ref(
         self, X_trace: np.ndarray, X_ref: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """Calculate and return covariances of trace references.
+        """
+        Calculate and return covariances of trace references.
 
         X_tr np.array of measurements of trace object, rows are repetitions, columns are features
         X_ref np.array of measurements of reference object, rows are repetitions, columns features
@@ -290,6 +422,18 @@ class TwoLevelModelNormalKDE:
             covars_trace_inv is the inverse of covars_trace,
             covars_trace_update_inv is the inverse of covars_trace_update,
             covars_ref_inv is the inverse of covars_ref.
+
+        Parameters
+        ----------
+        X_trace : np.ndarray
+            Value passed via ``X_trace``.
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+            Trace/reference covariance matrices and their inverses for scoring.
         """
         kernel_bandwidth_sq = check_not_none(self.kernel_bandwidth_sq)
         between_covars = check_not_none(self.between_covars)
@@ -326,10 +470,23 @@ class TwoLevelModelNormalKDE:
         )
 
     def _predict_updated_ref_mean(self, X_ref: np.ndarray, covars_ref_inv: np.ndarray) -> np.ndarray:
-        """Calculate and return bayesian update of reference mean given KDE background means.
+        """
+        Calculate and return bayesian update of reference mean given KDE background means.
 
         X_ref np.array of measurements of reference object, rows are repetitions, columns features
         returns: updated_ref_mean, bayesian update of reference mean given KDE background means.
+
+        Parameters
+        ----------
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+        covars_ref_inv : np.ndarray
+            Value passed via ``covars_ref_inv``.
+
+        Returns
+        -------
+        np.ndarray
+            Bayesian-updated reference means for each background source.
         """
         kernel_bandwidth_sq = check_not_none(self.kernel_bandwidth_sq)
         between_covars = check_not_none(self.between_covars)
@@ -359,7 +516,8 @@ class TwoLevelModelNormalKDE:
         covars_trace_update_inv: np.ndarray,
         updated_ref_mean: np.ndarray,
     ) -> np.floating:
-        """Perform calculation to predict natural log of numerator.
+        """
+        Perform calculation to predict natural log of numerator.
 
         See Bolck et al. formula in appendix. The formula consists of three sum_terms (and some other terms).
         The numerator sum term is calculated here.
@@ -373,6 +531,24 @@ class TwoLevelModelNormalKDE:
         covars_ref_inv, covars_trace_update_inv, np.arrays as calculated by _predict_covariances_trace_ref
         updated_ref_mean np.array with same dimensions as X, calculated by _predict_updated_ref_mean
         returns: ln_num1, natural log of numerator of the LR-formula in Bolck et al.
+
+        Parameters
+        ----------
+        X_trace : np.ndarray
+            Value passed via ``X_trace``.
+        X_ref : np.ndarray
+            Value passed via ``X_ref``.
+        covars_ref_inv : np.ndarray
+            Value passed via ``covars_ref_inv``.
+        covars_trace_update_inv : np.ndarray
+            Value passed via ``covars_trace_update_inv``.
+        updated_ref_mean : np.ndarray
+            Value passed via ``updated_ref_mean``.
+
+        Returns
+        -------
+        np.floating
+            Natural-log numerator term of the LR formula.
         """
         means_per_source = check_not_none(self.means_per_source)
         mean_X_trace = np.mean(X_trace, axis=0).reshape(1, -1)
@@ -391,7 +567,8 @@ class TwoLevelModelNormalKDE:
         return logsumexp(ln_num_terms)
 
     def _predict_ln_den_term(self, X_ref_or_trace: np.ndarray, covars_inv: np.ndarray) -> np.floating:
-        """Perform calculation and return natural log of a denominator term of the LR-formula.
+        """
+        Perform calculation and return natural log of a denominator term of the LR-formula.
 
         See Bolck et al. formula in appendix. The formula consists of three sum_terms (and some other terms).
         A denominator sum term is calculated here.
@@ -399,6 +576,18 @@ class TwoLevelModelNormalKDE:
         X_ref_or_trace np.array of measurements of reference or trace object, rows are repetitions, columns are features
         U_inv, np.array with respective covariance matrix as calculated by _predict_covariances_trace_ref
         returns: ln_den, natural log of a denominator term of the LR-formula in Bolck et al.
+
+        Parameters
+        ----------
+        X_ref_or_trace : np.ndarray
+            Value passed via ``X_ref_or_trace``.
+        covars_inv : np.ndarray
+            Value passed via ``covars_inv``.
+
+        Returns
+        -------
+        np.floating
+            Natural-log denominator term of the LR formula.
         """
         means_per_source = check_not_none(self.means_per_source)
         # calculate mean of reference or trace measurements and difference vectors (in matrix form)
@@ -419,13 +608,32 @@ class TwoLevelModelNormalKDE:
         ln_den_left: np.floating,
         ln_den_right: np.floating,
     ) -> np.floating:
-        """Predict 10-base logarithm LR's from the Bolck formula.
+        """
+        Predict 10-base logarithm LR's from the Bolck formula.
 
         X_trace np.array of measurements of trace object, rows are repetitions, columns are variables
         covars_trace, covars_trace_update, np.arrays as calculated by _predict_covariances_trace_ref
         ln_num, ln_den_left, ln_den_right: terms in big fraction in Bolck et al, as calculated by _predict_ln_num
             and _predict_ln_den_term
         returns: log10_LR_score, 10log of LR according to the LR-formula in Bolck et al.
+
+        Parameters
+        ----------
+        covars_trace : np.ndarray
+            Value passed via ``covars_trace``.
+        covars_trace_update : np.ndarray
+            Value passed via ``covars_trace_update``.
+        ln_num : np.floating
+            Value passed via ``ln_num``.
+        ln_den_left : np.floating
+            Value passed via ``ln_den_left``.
+        ln_den_right : np.floating
+            Value passed via ``ln_den_right``.
+
+        Returns
+        -------
+        np.floating
+            Final base-10 logarithm LR score.
         """
         assert self.n_sources is not None
         # calculate ln LR_score and change base to 10log
@@ -442,12 +650,22 @@ class TwoLevelModelNormalKDE:
 
 
 def _split_pairs(pairs: np.ndarray, n_trace: int) -> tuple[np.ndarray, np.ndarray]:
-    """Split the input array along the second dimension at position `n_trace`.
+    """
+    Split the input array along the second dimension at position `n_trace`.
 
-    :param pairs: a feature array of dimension: (pairs, instances, features)
-    :param n_trace: the number of trace instances
-    :return: a tuple of two arrays of trace features and reference features, both of dimension:
         (pairs, instances, features)
+
+    Parameters
+    ----------
+    pairs : np.ndarray
+        Value passed via ``pairs``.
+    n_trace : int
+        Value passed via ``n_trace``.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Tuple of trace features and reference features.
     """
     trace_features = pairs[:, :n_trace, :]
     ref_features = pairs[:, n_trace:, :]
@@ -455,12 +673,26 @@ def _split_pairs(pairs: np.ndarray, n_trace: int) -> tuple[np.ndarray, np.ndarra
 
 
 class TwoLevelSystem(LRSystem):
-    """Implement two level model, common-source feature-based LR system architecture.
+    """
+    Implement two level model, common-source feature-based LR system architecture.
 
     During the training phase, the system calculates statistics on the unpaired instances. On application, it
     calculates LRs for same-source and different-source pairs. Each side of the pair may consist of multiple instances.
 
     See also: `TwoLevelModelNormalKDE`
+
+    Parameters
+    ----------
+    preprocessing_pipeline : Transformer | None
+        Pipeline that preprocesses instances before pairing and evaluation.
+    pairing_function : PairingMethod
+        Pairing method used to construct trace/reference comparisons.
+    postprocessing_pipeline : Transformer | None
+        Value passed via ``postprocessing_pipeline``.
+    n_trace_instances : int
+        Number of trace instances to include in each pairing.
+    n_ref_instances : int
+        Number of reference instances to include in each pairing.
     """
 
     def __init__(
@@ -471,12 +703,23 @@ class TwoLevelSystem(LRSystem):
         n_trace_instances: int,
         n_ref_instances: int,
     ):
-        """Initialize a new TwoLevelSystem instance.
+        """
+        Initialize a new TwoLevelSystem instance.
 
-        :param preprocessing_pipeline: a preprocessing pipeline that is applied on unpaired instances
-        :param pairing_function: a function to generate same-source and different-source pairs
-        :param postprocessing_pipeline: a postprocessing pipeline that is applied *after* applying the two level model;
             it takes LLRs as input.
+
+        Parameters
+        ----------
+        preprocessing_pipeline : Transformer | None
+            Pipeline that preprocesses instances before pairing and evaluation.
+        pairing_function : PairingMethod
+            Pairing method used to construct trace/reference comparisons.
+        postprocessing_pipeline : Transformer | None
+            Value passed via ``postprocessing_pipeline``.
+        n_trace_instances : int
+            Number of trace instances to include in each pairing.
+        n_ref_instances : int
+            Number of reference instances to include in each pairing.
         """
         self.preprocessing_pipeline = preprocessing_pipeline or Pipeline([])
         self.pairing_function = pairing_function
@@ -486,7 +729,19 @@ class TwoLevelSystem(LRSystem):
         self.n_ref_instances = n_ref_instances
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model based on the instance data."""
+        """
+        Fit the model based on the instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This LR system instance after fitting all components.
+        """
         instances = self.preprocessing_pipeline.fit_apply(instances)
         instances = check_type(FeatureData, instances, 'preprocessing pipeline should return FeatureData')
         self.model.fit_on_unpaired_instances(instances.features, instances.source_ids_1d)
@@ -498,10 +753,21 @@ class TwoLevelSystem(LRSystem):
         return self
 
     def apply(self, instances: InstanceData) -> LLRData:
-        """Apply this LR system on a set of instances and return LLR data.
+        """
+        Apply this LR system on a set of instances and return LLR data.
 
         Applies the two level LR system on a set of instances,
         and returns a representation of the calculated LLR data through the `LLRData` tuple.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        LLRData
+            Likelihood-ratio data produced by applying the LR system.
         """
         instances = self.preprocessing_pipeline.apply(instances)
 

--- a/lir/main.py
+++ b/lir/main.py
@@ -21,9 +21,13 @@ DEFAULT_LOGLEVEL = logging.WARNING
 
 
 def setup_logging(level_increase: int) -> None:
-    """Set up logging to stderr and to a file.
+    """
+    Set up logging to stderr and to a file.
 
-    :param level_increase: log level for stderr, relative to the default log level
+    Parameters
+    ----------
+    level_increase : int
+        Log level for stderr, relative to the default log level.
     """
     loglevel = max(logging.DEBUG, min(logging.CRITICAL, DEFAULT_LOGLEVEL - level_increase * 10))
 
@@ -40,7 +44,14 @@ def setup_logging(level_increase: int) -> None:
 
 
 def initialize_logfile(output_dir: Path) -> None:
-    """Set up logfile for debugging purposes when running experiment."""
+    """
+    Set up logfile for debugging purposes when running experiment.
+
+    Parameters
+    ----------
+    output_dir : Path
+        The directory where the logfile should be created.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     fh = logging.FileHandler(output_dir / 'log.txt')
     fh.setFormatter(logging.Formatter('[%(asctime)-15s %(levelname)s] %(name)s: %(message)s'))
@@ -49,7 +60,16 @@ def initialize_logfile(output_dir: Path) -> None:
 
 
 def copy_yaml_definition(output_dir: Path, config_yaml_path: Path) -> None:
-    """Copy the YAML definition for a given LR system experiment to persist the used configuration."""
+    """
+    Copy the YAML definition for a given LR system experiment to persist the used configuration.
+
+    Parameters
+    ----------
+    output_dir : Path
+        The directory where the YAML definition should be copied.
+    config_yaml_path : Path
+        The path to the YAML file describing the experiment configuration.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(config_yaml_path, output_dir / 'config.yaml')
 
@@ -57,14 +77,22 @@ def copy_yaml_definition(output_dir: Path, config_yaml_path: Path) -> None:
 def initialize_experiments(
     cfg: confidence.Configuration,
 ) -> tuple[Mapping[str, Experiment], Path]:
-    """Extract which Experiment to run as dictated in the configuration.
+    """
+    Extract which Experiment to run as dictated in the configuration.
 
     The following pre-defined variables are injected to the configuration:
 
     - `timestamp`: a formatted timestamp of the current date/time
 
-    :param cfg: a `Configuration` object describing the experiments
-    :return: a tuple with two elements: (1) mapping of names to experiments; (2) path to output directory
+    Parameters
+    ----------
+    cfg : confidence.Configuration
+        A `Configuration` object describing the experiments.
+
+    Returns
+    -------
+    tuple[Mapping[str, Experiment], Path]
+        A tuple with two elements: (1) mapping of names to experiments; (2) path to output directory.
     """
     cfg = confidence.Configuration(cfg, {'timestamp': datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')})  # noqa: DTZ005
 
@@ -77,14 +105,30 @@ def initialize_experiments(
 
 
 def error(msg: str, e: Exception | None = None) -> None:
-    """Stop execution with given error message or raise exception."""
+    """
+    Stop execution with given error message or raise exception.
+
+    Parameters
+    ----------
+    msg : str
+        The error message to be printed to stderr.
+    e : Exception | None
+        The exception to be raised, or None to not raise an exception.
+    """
     sys.stderr.write(f'{msg}{" (see log for details)" if e else ""}\n')
     LOG.debug(f'abort: {msg}', exc_info=e)
     sys.exit(1)
 
 
 def main(input_args: list[str] | None = None) -> None:
-    """Provide Command Line Interface (CLI) to LiR."""
+    """
+    Run all or some of the parts of project.
+
+    Parameters
+    ----------
+    input_args : list[str] | None
+        The command-line arguments to parse, or None to parse the actual command-line arguments.
+    """
     parser = argparse.ArgumentParser(description='Run all or some of the parts of project')
 
     parser.add_argument(

--- a/lir/metrics/__init__.py
+++ b/lir/metrics/__init__.py
@@ -6,14 +6,23 @@ from lir.util import Xy_to_Xn, logodds_to_odds
 
 
 def cllr(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
-    """Calculate a log likelihood ratio cost (C_llr) for a series of log likelihood ratios.
+    """
+    Calculate a log likelihood ratio cost (C_llr) for a series of log likelihood ratios.
 
     Nico Brümmer and Johan du Preez, Application-independent evaluation of speaker detection, In: Computer Speech and
     Language 20(2-3), 2006.
 
-    :param llr_data: LLRs and their metadata, wrapped in an LLRData object
-    :param weights: the relative weights of the classes
-    :return: CLLR, the log likelihood ratio cost
+    Parameters
+    ----------
+    llr_data : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+    weights : tuple[float, float], optional
+        The relative weights of the classes.
+
+    Returns
+    -------
+    float
+        CLLR, the log likelihood ratio cost.
     """
     llrs, y = llr_data.llrs, llr_data.require_labels
 
@@ -30,11 +39,20 @@ def cllr(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
 
 
 def cllr_min(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
-    """Estimate the discriminative power from a collection of log likelihood ratios.
+    """
+    Estimate the discriminative power from a collection of log likelihood ratios.
 
-    :param llr_data: LLRs and their metadata, wrapped in an LLRData object
-    :param weights: the relative weights of the classes
-    :return: CLLR_min, a measure of discrimination
+    Parameters
+    ----------
+    llr_data : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+    weights : tuple[float, float], optional
+        The relative weights of the classes.
+
+    Returns
+    -------
+    float
+        CLLR_min, a measure of discrimination.
     """
     if not np.all(np.unique(llr_data.require_labels) == [0, 1]):
         return np.nan
@@ -46,11 +64,20 @@ def cllr_min(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
 
 
 def cllr_cal(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
-    """Calculate the difference between the C_llr before and after isotonic calibration.
+    """
+    Calculate the difference between the C_llr before and after isotonic calibration.
 
-    :param llr_data: LLRs and their metadata, wrapped in an LLRData object
-    :param weights: the relative weights of the classes
-    :return: CLLR_cal, the difference after isotonic calibration
+    Parameters
+    ----------
+    llr_data : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+    weights : tuple[float, float], optional
+        The relative weights of the classes.
+
+    Returns
+    -------
+    float
+        CLLR_cal, the difference after isotonic calibration.
     """
     cllr_min_val = cllr_min(llr_data, weights)
     cllr_val = cllr(llr_data, weights)
@@ -59,22 +86,38 @@ def cllr_cal(llr_data: LLRData, weights: tuple[float, float] = (1, 1)) -> float:
 
 
 def llr_upper_bound(llrs: LLRData) -> float | None:
-    """Provide corresponding upper bound for provided LLR data.
+    """
+    Provide corresponding upper bound for provided LLR data.
 
     When an LLRData object contains an upper bound, return it. If not, return None.
 
-    :param llrs: LLRs and their metadata, wrapped in an LLRData object
-    :return: the LLR upper bound, or None
+    Parameters
+    ----------
+    llrs : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+
+    Returns
+    -------
+    float | None
+        The LLR upper bound, or `None`.
     """
     return llrs.llr_upper_bound
 
 
 def llr_lower_bound(llrs: LLRData) -> float | None:
-    """Provide corresponding lower bound for provided LLR data.
+    """
+    Provide corresponding lower bound for provided LLR data.
 
     When an LLRData object contains a lower bound, return it. If not, return None.
 
-    :param llrs: LLRs and their metadata, wrapped in an LLRData object
-    :return: the LLR lower bound, or None
+    Parameters
+    ----------
+    llrs : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+
+    Returns
+    -------
+    float | None
+        The LLR lower bound, or `None`.
     """
     return llrs.llr_lower_bound

--- a/lir/metrics/devpav.py
+++ b/lir/metrics/devpav.py
@@ -71,12 +71,14 @@ def _devpavcalculator(lrs: np.ndarray, pav_lrs: np.ndarray, y: np.ndarray) -> fl
     """
     Calculate devPAV for PAV-transformed LRs.
 
-    Parameters:
+    Parameters
+    ----------
     - lrs: np.ndarray of LR values.
     - pav_lrs: np.ndarray of LRs after PAV transformation.
     - y: np.ndarray of labels (1 for H1 and 0 for H2).
 
-    Returns:
+    Returns
+    -------
     - float: devPAV value
 
     """

--- a/lir/metrics/devpav.py
+++ b/lir/metrics/devpav.py
@@ -6,7 +6,21 @@ from lir.util import Xy_to_Xn, logodds_to_odds
 
 
 def _calcsurface(c1: tuple[float, float], c2: tuple[float, float]) -> float:
-    """Calculate the desired surface for two xy-coordinates."""
+    """
+    Calculate the desired surface for two xy-coordinates.
+
+    Parameters
+    ----------
+    c1 : tuple[float, float]
+        First coordinate as `(x, y)`.
+    c2 : tuple[float, float]
+        Second coordinate as `(x, y)`.
+
+    Returns
+    -------
+    float
+        Surface between line segment `c1`-`c2` and the identity line.
+    """
     # step 1: calculate intersection (xs, ys) of straight line through coordinates with identity line (if slope (a) = 1,
     # there is no intersection and surface of this parallelogram is equal to deltaY * deltaX)
 
@@ -73,14 +87,17 @@ def _devpavcalculator(lrs: np.ndarray, pav_lrs: np.ndarray, y: np.ndarray) -> fl
 
     Parameters
     ----------
-    - lrs: np.ndarray of LR values.
-    - pav_lrs: np.ndarray of LRs after PAV transformation.
-    - y: np.ndarray of labels (1 for H1 and 0 for H2).
+    lrs : np.ndarray
+        Array of LR values.
+    pav_lrs : np.ndarray
+        Array of LRs after PAV transformation.
+    y : np.ndarray
+        Array of labels (`1` for H1 and `0` for H2).
 
     Returns
     -------
-    - float: devPAV value
-
+    float
+        DevPAV value.
     """
     # split same-source and different-source LRs and PAV-LRs
     ds_lrs, ss_lrs = Xy_to_Xn(lrs, y)
@@ -130,7 +147,19 @@ def _devpavcalculator(lrs: np.ndarray, pav_lrs: np.ndarray, y: np.ndarray) -> fl
 
 
 def devpav(llrs: LLRData) -> float:
-    """Calculate devPAV for LR data under H1 and H2."""
+    """
+    Calculate devPAV for LR data under H1 and H2.
+
+    Parameters
+    ----------
+    llrs : LLRData
+        LLRs and their metadata, wrapped in an `LLRData` object.
+
+    Returns
+    -------
+    float
+        DevPAV score.
+    """
     labels = llrs.check_both_labels()
     cal = IsotonicCalibrator()
     pavllrs = cal.fit_apply(llrs)

--- a/lir/metrics/overestimation.py
+++ b/lir/metrics/overestimation.py
@@ -6,7 +6,23 @@ from lir.algorithms.llr_overestimation import calc_llr_overestimation
 
 
 def llr_overestimation(llrs: np.ndarray, y: np.ndarray, **kwargs: Any) -> float:
-    """Calculate the mean absolute value of the LLR-overestimation."""
+    """
+    Calculate the mean absolute value of the LLR-overestimation.
+
+    Parameters
+    ----------
+    llrs : np.ndarray
+        Array of log-likelihood ratios.
+    y : np.ndarray
+        Array of labels (`1` for H1 and `0` for H2).
+    **kwargs : Any
+        Additional keyword arguments forwarded to `calc_llr_overestimation`.
+
+    Returns
+    -------
+    float
+        Mean absolute value of the overestimation grid, or `np.nan` when unavailable.
+    """
     _, llr_overestimation_grid, _ = calc_llr_overestimation(llrs, y, num_fids=0, **kwargs)
     if llr_overestimation_grid is not None and llr_overestimation_grid.all():
         return float(np.mean(np.abs(llr_overestimation_grid)))

--- a/lir/persistence.py
+++ b/lir/persistence.py
@@ -8,7 +8,19 @@ from lir.lrsystems.lrsystems import LRSystem
 
 
 def load_model(path: Path) -> LRSystem:
-    """Load previously cached model."""
+    """
+    Load previously cached model.
+
+    Parameters
+    ----------
+    path : Path
+        The path to the .pkl file containing the model.
+
+    Returns
+    -------
+    LRSystem
+        The loaded model.
+    """
     try:
         with open(path, 'rb') as f:
             # It is assumed exclusively `LRSystem` models will be loaded, which are considered safe
@@ -18,14 +30,32 @@ def load_model(path: Path) -> LRSystem:
 
 
 def save_model(path: Path, model: LRSystem) -> None:
-    """Save a model to disk."""
+    """
+    Save a model to disk.
+
+    Parameters
+    ----------
+    path : Path
+        The path to the .pkl file where the model should be saved.
+    model : LRSystem
+        The model to be saved.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, 'wb') as f:
         f.write(pickle.dumps(model))
 
 
 class SaveModel(Aggregation):
-    """Write the model to a file."""
+    """
+    Write the model to a file.
+
+    Parameters
+    ----------
+    output_dir : Path
+        The directory where the model should be written.
+    filename : PathLike | str
+        The filename to be created for the model.
+    """
 
     def __init__(self, output_dir: Path, filename: PathLike | str = 'model.pkl') -> None:
         """
@@ -37,14 +67,25 @@ class SaveModel(Aggregation):
         If `filename` is an absolute path, or if `filename` is relative to `output_dir`, then the model is saved to this
         file as-is, instead of to a file in a newly created subdirectory.
 
-        :param output_dir: the directory where the model should be written
-        :param filename: the filename to be created for the model
+        Parameters
+        ----------
+        output_dir : Path
+            The directory where the model should be written.
+        filename : PathLike | str
+            The filename to be created for the model.
         """
         self.output_dir = output_dir
         self.filename = Path(filename)
 
     def report(self, data: AggregationData) -> None:
-        """Create a directory for the run and write the trained LR system model to file."""
+        """
+        Create a directory for the run and write the trained LR system model to file.
+
+        Parameters
+        ----------
+        data : AggregationData
+            The data to be aggregated, containing the trained LR system model and the run name.
+        """
         path = self._resolve_output_path(self.output_dir, self.filename, data.run_name)
         save_model(path, data.lrsystem)
 
@@ -54,8 +95,17 @@ def parse_save_model(config: ContextAwareDict, output_dir: Path) -> SaveModel:
     """
     Parse a configuration section that describes how a `SaveModel` instance should be instantiated.
 
-    :param config: the configuration section
-    :param output_dir: directory where the instantiated object may write its output
+    Parameters
+    ----------
+    config : ContextAwareDict
+        The configuration section.
+    output_dir : Path
+        Directory where the instantiated object may write its output.
+
+    Returns
+    -------
+    SaveModel
+        The instantiated object.
     """
     filename = pop_field(config, 'filename', default='model.pkl', validate=str)
     check_is_empty(config)

--- a/lir/plotting/__init__.py
+++ b/lir/plotting/__init__.py
@@ -26,9 +26,24 @@ H2_COLOR = 'blue'
 
 
 class Canvas:
-    """Representation of an empty canvas, to be used in plotting multiple visualizations."""
+    """
+    Representation of an empty canvas, to be used in plotting multiple visualizations.
+
+    Parameters
+    ----------
+    ax : Axes
+        Matplotlib axes instance used by wrapped plotting methods.
+    """
 
     def __init__(self, ax: Axes):
+        """
+        Initialize a plotting canvas wrapper.
+
+        Parameters
+        ----------
+        ax : Axes
+            Matplotlib axes instance used by wrapped plotting methods.
+        """
         self.ax = ax
 
         self.ece = partial(ece, ax)
@@ -40,7 +55,21 @@ class Canvas:
         self.llr_interval = partial(llr_interval, ax)
 
     def title(self, label: str, **kwargs: Any) -> Any:
-        """Set the title of the axes (wrapper for set_title)."""
+        """
+        Set the title of the axes (wrapper for `set_title`).
+
+        Parameters
+        ----------
+        label : str
+            Title text.
+        **kwargs : Any
+            Additional keyword arguments forwarded to `Axes.set_title`.
+
+        Returns
+        -------
+        Any
+            Return value from `Axes.set_title`.
+        """
         return self.ax.set_title(label, **kwargs)
 
     def __getattr__(self, attr: str) -> Any:
@@ -51,8 +80,18 @@ def savefig(path: str) -> _GeneratorContextManager[Canvas]:
     """
     Create a plotting context and write the figure to a file when the context exits.
 
-    Example
+    Parameters
+    ----------
+    path : str
+        Path to the output file. The figure is written as a PNG image.
+
+    Returns
     -------
+    _GeneratorContextManager[Canvas]
+        Context manager yielding a `Canvas` and saving on exit.
+
+    Examples
+    --------
     .. code-block:: python
 
         with savefig(path) as ax:
@@ -60,11 +99,6 @@ def savefig(path: str) -> _GeneratorContextManager[Canvas]:
 
     A call to :func:`savefig` is equivalent to calling :func:`axes` with
     ``savefig=path``.
-
-    Parameters
-    ----------
-    path : str
-        Path to the output file. The figure is written as a PNG image.
     """
     return axes(savefig=path)
 
@@ -73,8 +107,13 @@ def show() -> _GeneratorContextManager[Canvas]:
     """
     Create a plotting context and show the figure when the context exits.
 
-    Example
+    Returns
     -------
+    _GeneratorContextManager[Canvas]
+        Context manager yielding a `Canvas` and showing the figure on exit.
+
+    Examples
+    --------
     .. code-block:: python
 
         with show() as ax:
@@ -88,10 +127,23 @@ def show() -> _GeneratorContextManager[Canvas]:
 
 @contextmanager
 def axes(savefig: PathLike | str | None = None, show: bool | None = None) -> Iterator[Canvas]:
-    """Create a plotting context.
+    """
+    Create a plotting context.
 
-    Example
+    Parameters
+    ----------
+    savefig : PathLike | str | None, optional
+        File path to save the figure on context exit.
+    show : bool | None, optional
+        Whether to display the figure on context exit.
+
+    Returns
     -------
+    Iterator[Canvas]
+        Iterator yielding a `Canvas` instance for plotting.
+
+    Examples
+    --------
     .. code-block:: python
 
         with axes() as ax:
@@ -114,18 +166,19 @@ def pav(
     add_misleading: int = 0,
     show_scatter: bool = True,
 ) -> None:
-    """Generate a plot of pre-calibrated versus post-calibrated LRs using Pool Adjacent Violators (PAV).
+    """
+    Generate a plot of pre-calibrated versus post-calibrated LRs using Pool Adjacent Violators (PAV).
 
     Parameters
     ----------
     ax : Axes
-        The matplotlib axes object to plot on
+        The matplotlib axes object to plot on.
     llrdata : LLRData
-        The LLRData object containing likelihood ratios and labels
+        The LLRData object containing likelihood ratios and labels.
     add_misleading : int, optional
-        number of misleading evidence points to add on both sides (default: ``0``)
+        Number of misleading evidence points to add on both sides (default: ``0``).
     show_scatter : bool, optional
-        If True, show individual LRs (default: ``True``)
+        If `True`, show individual LRs (default: ``True``).
     """
     llrs = llrdata.llrs
     y = llrdata.labels
@@ -250,18 +303,19 @@ def lr_histogram(
     bins: int = 20,
     weighted: bool = True,
 ) -> None:
-    """Plot the 10log lrs.
+    """
+    Plot the 10log LRs.
 
     Parameters
     ----------
     ax : Axes
-        The matplotlib axes object to plot on
+        The matplotlib axes object to plot on.
     llrdata : LLRData
-        The LLRData object containing likelihood ratios and labels
+        The LLRData object containing likelihood ratios and labels.
     bins : int
-        number of bins to divide scores into (default: 20)
+        Number of bins to divide scores into (default: 20).
     weighted : bool
-        if y-axis should be weighted for frequency within each class (default: True)
+        If y-axis should be weighted for frequency within each class (default: `True`).
     """
     llrs = llrdata.llrs
     y = llrdata.require_labels
@@ -281,16 +335,17 @@ def lr_histogram(
 
 
 def tippett(ax: Axes, llrdata: LLRData, plot_type: int = 1) -> None:
-    """Plot empirical cumulative distribution functions of same-source and different-sources lrs.
+    """
+    Plot empirical cumulative distribution functions of same-source and different-sources LRs.
 
     Parameters
     ----------
     ax : Axes
-        The matplotlib axes object to plot on
+        The matplotlib axes object to plot on.
     llrdata : LLRData
-        The LLRData object containing likelihood ratios and labels
+        The LLRData object containing likelihood ratios and labels.
     plot_type : int
-        must be either 1 or 2 (default: 1).
+        Must be either 1 or 2 (default: 1).
         In type 1 both curves show proportion of lrs greater than or equal to the
         x-axis value, while in type 2 the curve for same-source shows the
         proportion of lrs smaller than or equal to the x-axis value.
@@ -317,12 +372,13 @@ def tippett(ax: Axes, llrdata: LLRData, plot_type: int = 1) -> None:
 
 
 def llr_interval(ax: Axes, llrdata: LLRData) -> None:
-    """Plot the lr's on the x axis, with the relative interval score on the y axis.
+    """
+    Plot the LRs on the x-axis, with the relative interval score on the y-axis.
 
     Parameters
     ----------
     ax : Axes
-        The matplotlib axes object to plot on
+        The matplotlib axes object to plot on.
     llrdata : LLRData
         The LLRData object containing the likelihood ratios and interval scores.
     """
@@ -352,7 +408,8 @@ def score_distribution(
     bins: int = 20,
     weighted: bool = True,
 ) -> None:
-    """Plot the distributions of scores calculated by the (fitted) lr_system.
+    """
+    Plot the distributions of scores calculated by the (fitted) LR system.
 
     If `weighted` is `True`, the y-axis represents the probability density
     within the class, and `inf` is the fraction of instances. Otherwise, the
@@ -361,16 +418,16 @@ def score_distribution(
     Parameters
     ----------
     ax : Axes
-        The matplotlib axes object to plot on
+        The matplotlib axes object to plot on.
     scores : np.ndarray
-        scores of (fitted) lr_system (1d-array)
+        Scores of the (fitted) LR system (1d-array).
     y : np.ndarray
-        a numpy array of labels (0 or 1, 1d-array of same length as `scores`)
+        A numpy array of labels (0 or 1, 1d-array of same length as `scores`).
     bins : int
-        number of bins to divide scores into (default: 20)
+        Number of bins to divide scores into (default: 20).
     weighted : bool
-        if y-axis should be the probability density within each class,
-        instead of counts (default: True)
+        If y-axis should be the probability density within each class,
+        instead of counts (default: `True`).
     """
     plt.rcParams.update({'font.size': 15})
 

--- a/lir/plotting/expected_calibration_error.py
+++ b/lir/plotting/expected_calibration_error.py
@@ -51,12 +51,12 @@ def plot_ece(
 
     Parameters
     ----------
+    ax : matplotlib.axes.Axes
+        Matplotlib axes to plot into.
     llrdata : LLRData
         LLR data containing LLR values and corresponding labels.
     log_prior_odds_range : tuple[float, float], optional
         Range of log prior odds shown on the x-axis, given as ``(min, max)``.
-    ax : matplotlib.axes.Axes, optional
-        Matplotlib axes to plot into. If ``None``, the current axes are used.
     show_pav : bool, optional
         Whether to include the PAV-transformed LRs in the plot.
     ylim : {"neutral", "zoomed"}, optional
@@ -118,16 +118,25 @@ def plot_ece(
 
 
 def calculate_ece(lrs: np.ndarray, y: np.ndarray, priors: np.ndarray) -> np.ndarray:
-    """Calculate empirical cross-entropy (ECE) of a set of LRs and corresponding ground-truth labels.
+    """
+    Calculate empirical cross-entropy (ECE) of a set of LRs and corresponding ground-truth labels.
 
     An entropy is calculated for each element of `priors`.
 
-    :param lrs: an array of LRs
-    :param y: an array of ground-truth labels of the LRs (values 0 for Hd or 1
-        for Hp); must be of the same length as `lrs`.
-    :param priors: an array of prior probabilities of the samples being drawn
-        from class 1 (values in range [0..1])
-    :returns: an array of entropy values of the same length as `priors`
+    Parameters
+    ----------
+    lrs : np.ndarray
+        Array of likelihood ratios.
+    y : np.ndarray
+        Array of ground-truth labels for the LRs (`0` for Hd or `1` for Hp),
+        with the same length as `lrs`.
+    priors : np.ndarray
+        Array of prior probabilities for class 1 (values in the range `[0, 1]`).
+
+    Returns
+    -------
+    np.ndarray
+        Array of entropy values with the same length as `priors`.
     """
     assert np.all(lrs >= 0), 'invalid input for LR values'
     assert np.all(np.unique(y) == np.array([0, 1])), 'label set must be [0, 1]'

--- a/lir/registry.py
+++ b/lir/registry.py
@@ -16,7 +16,20 @@ LOG = logging.getLogger(__name__)
 
 
 def _get_attribute_by_name(name: str) -> Any:
-    """Resolve the corresponding function or class in this project from the configuration string."""
+    """
+    Resolve the corresponding function or class in this project from the configuration string.
+
+    Parameters
+    ----------
+    name : str
+        The name of the function or class to resolve, specified as a full path (
+        for example: 'lir.transform.base.BaseTransform').
+
+    Returns
+    -------
+    Any
+        The function or class corresponding to the given name.
+    """
     parts = name.split('.')
 
     LOG.debug(f'{name} is being resolved')
@@ -59,7 +72,8 @@ class InvalidRegistryEntryError(ValueError):
 
 
 class ConfigParserLoader(ABC, Iterable):
-    """Base class for a configuration parser loader.
+    """
+    Base class for a configuration parser loader.
 
     A configuration parser is able to interpret a dictionary-style configuration loaded from a YAML. Sub classes are
     expected to implement the `get()` method.
@@ -86,16 +100,25 @@ class ConfigParserLoader(ABC, Iterable):
         default_config_parser: Callable[[Any], ConfigParser] | None = None,
         search_path: list[str] | None = None,
     ) -> ConfigParser:
-        """Retrieve a value for a given key name.
+        """
+        Retrieve a value for a given key name.
 
         The key may resolve to a `ConfigParser` class, or it is passed as an argument to `default_config_parser`, which
         in turn returns a `ConfigParser` class.
 
-        :param key: the key name to resolve
-        :param default_config_parser: a function that returns a `ConfigParser` if the `key` does not resolve to a
-            `ConfigParser`
-        :param search_path: the domain of the search query
-        :return: a `ConfigParser` object
+        Parameters
+        ----------
+        key : str
+            The key name to resolve.
+        default_config_parser : Callable[[Any], ConfigParser] | None, optional
+            A function that returns a `ConfigParser` if the `key` does not resolve to a `ConfigParser`, by default None.
+        search_path : list[str] | None, optional
+            The domain of the search query, by default None.
+
+        Returns
+        -------
+        ConfigParser
+            A `ConfigParser` object.
         """
         raise NotImplementedError
 
@@ -112,7 +135,23 @@ class ClassLoader(ConfigParserLoader):
         default_config_parser: Callable[[Any], ConfigParser] | None = None,
         search_path: list[str] | None = None,
     ) -> ConfigParser:
-        """Get the accompanying config parser class from the registry."""
+        """
+        Get the accompanying config parser class from the registry.
+
+        Parameters
+        ----------
+        key : str
+            The key name to resolve, expected to be a full class name (for example: 'lir.transform.base.BaseTransform').
+        default_config_parser : Callable[[Any], ConfigParser] | None, optional
+            A function that returns a `ConfigParser` if the `key` does not resolve to a `ConfigParser`, by default None.
+        search_path : list[str] | None, optional
+            The domain of the search query, by default None.
+
+        Returns
+        -------
+        ConfigParser
+            A `ConfigParser` object.
+        """
         parts = key.split('.')
         if len(parts) < 2:
             raise ComponentNotFoundError(f'no full class name: {key}')
@@ -128,9 +167,24 @@ class ClassLoader(ConfigParserLoader):
 
 
 class FederatedLoader(ConfigParserLoader):
-    """A configuration parser loader that delegates resolution to other loaders."""
+    """
+    A configuration parser loader that delegates resolution to other loaders.
+
+    Parameters
+    ----------
+    registries : list[ConfigParserLoader]
+        A list of configuration parser loaders to delegate to, in order of priority.
+    """
 
     def __init__(self, registries: list[ConfigParserLoader]):
+        """
+        Initialize the federated loader with a list of registries to delegate to.
+
+        Parameters
+        ----------
+        registries : list[ConfigParserLoader]
+            A list of configuration parser loaders to delegate to, in order of priority.
+        """
         self.registries = registries
 
     def __iter__(self) -> Iterator[str]:
@@ -143,7 +197,23 @@ class FederatedLoader(ConfigParserLoader):
         default_config_parser: Callable[[Any], ConfigParser] | None = GenericConfigParser,
         search_path: list[str] | None = None,
     ) -> ConfigParser:
-        """Get the accompanying config parser class from the registry."""
+        """
+        Get the accompanying config parser class from the registry.
+
+        Parameters
+        ----------
+        key : str
+            The key name to resolve.
+        default_config_parser : Callable[[Any], ConfigParser] | None, optional
+            A function that returns a `ConfigParser` if the `key` does not resolve to a `ConfigParser`.
+        search_path : list[str] | None, optional
+            The domain of the search query, by default None.
+
+        Returns
+        -------
+        ConfigParser
+            A `ConfigParser` object.
+        """
         errors = []
         for r in self.registries:
             try:
@@ -170,7 +240,14 @@ def _load_package_registry() -> 'YamlRegistry':
 
 
 def registry() -> ConfigParserLoader:
-    """Provide access to a centralized registry of available configuration options."""
+    """
+    Provide access to a centralized registry of available configuration options.
+
+    Returns
+    -------
+    ConfigParserLoader
+        A configuration parser loader that can be used to retrieve configuration parsers for various components.
+    """
     global _REGISTRY
     if _REGISTRY is None:
         try:
@@ -187,12 +264,29 @@ def get(
     default_config_parser: Callable[[Any], ConfigParser] | None = None,
     search_path: list[str] | None = None,
 ) -> ConfigParser:
-    """Retrieve corresponding value for a given key name from the central registry."""
+    """
+    Retrieve corresponding value for a given key name from the central registry.
+
+    Parameters
+    ----------
+    name : str
+        The key name to resolve.
+    default_config_parser : Callable[[Any], ConfigParser] | None, optional
+        A function that returns a `ConfigParser` if the `key` does not resolve to a `ConfigParser`, by default None.
+    search_path : list[str] | None, optional
+        The domain of the search query, by default None.
+
+    Returns
+    -------
+    ConfigParser
+        A `ConfigParser` object.
+    """
     return registry().get(name, default_config_parser, search_path)
 
 
 class YamlRegistry(ConfigParserLoader):
-    """Representation of a YAML-based registry.
+    """
+    Representation of a YAML-based registry.
 
     The YAML registry is expected to define "sections" as the top-level
     key names, followed by keys referring to (paths to) classnames or
@@ -200,6 +294,11 @@ class YamlRegistry(ConfigParserLoader):
 
     This registry parses this YAML mapping and provides access to these
     values through a `get()` method.
+
+    Parameters
+    ----------
+    cfg : confidence.Configuration
+        The configuration object containing the registry entries.
     """
 
     def __init__(self, cfg: confidence.Configuration):
@@ -244,10 +343,23 @@ class YamlRegistry(ConfigParserLoader):
         return parser
 
     def _find(self, key: str, search_path: list[str] | None) -> Any:
-        """Locate the value for a given key name in the YAML-based registry.
+        """
+        Locate the value for a given key name in the YAML-based registry.
 
         The search path is used to prefix the key name with possible
         domain (for example: 'modules' or 'data_provider').
+
+        Parameters
+        ----------
+        key : str
+            The key name to resolve.
+        search_path : list[str] | None, optional
+            The domain of the search query, by default None.
+
+        Returns
+        -------
+        Any
+            The value associated with the key in the registry.
         """
         try_keys = [key]
 
@@ -280,6 +392,20 @@ class YamlRegistry(ConfigParserLoader):
                 class: ObjectName
 
         In the example, ``ObjectName`` refers to a Python object available in the current runtime.
+
+        Parameters
+        ----------
+        key : str
+            The key name to resolve.
+        default_config_parser : Callable[[Any], ConfigParser] | None, optional
+            A function that returns a `ConfigParser` if the `key` does not resolve to a `ConfigParser`, by default None.
+        search_path : list[str] | None, optional
+            The domain of the search query, by default None.
+
+        Returns
+        -------
+        ConfigParser
+            A `ConfigParser` object.
         """
         spec = self._find(key, search_path)
         if isinstance(spec, str):

--- a/lir/transform/__init__.py
+++ b/lir/transform/__init__.py
@@ -19,7 +19,14 @@ class DataWriter(Protocol):
     """Representation of a data writer and necessary methods."""
 
     def writerow(self, row: Any) -> None:
-        """Write row to output."""
+        """
+        Write row to output.
+
+        Parameters
+        ----------
+        row : Any
+            CSV row dictionary to parse.
+        """
         pass
 
 
@@ -40,7 +47,8 @@ class SklearnTransformerType(Protocol):
 
 
 class Transformer(ABC):
-    """Transformer module which is compatible with the scikit-learn `Pipeline`.
+    """
+    Transformer module which is compatible with the scikit-learn `Pipeline`.
 
     The transformer should provide a `transform()` method. Since transformers are not
     fitted to the data, the `fit()` simply returns the object it was called upon without
@@ -48,44 +56,124 @@ class Transformer(ABC):
     """
 
     def fit(self, instances: InstanceData) -> Self:
-        """Perform (optional) fitting of the instance data."""
+        """
+        Perform (optional) fitting of the instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This transformer instance after fitting.
+        """
         return self
 
     @abstractmethod
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Convert the instance data based on the (optionally fitted) model."""
+        """
+        Convert the instance data based on the (optionally fitted) model.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         raise NotImplementedError
 
     def fit_apply(self, instances: InstanceData) -> InstanceData:
-        """Combine call to `fit()` with directly following call to `apply()`."""
+        """
+        Combine call to `fit()` with directly following call to `apply()`.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         return self.fit(instances).apply(instances)
 
 
 class Identity(Transformer):
-    """Represent the Identity function of a transformer.
+    """
+    Represent the Identity function of a transformer.
 
     When `apply()` is called on such a transformer, it simply returns the instances.
     """
 
     def apply(self, instances: InstanceDataType) -> InstanceDataType:
-        """Simply provide the instances."""
+        """
+        Simply provide the instances.
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceDataType
+            Instance data object produced by this operation.
+        """
         return instances
 
 
 class BinaryClassifierTransformer(Transformer):
-    """Implementation of a binary class classifier as scikit-learn `Pipeline` step."""
+    """
+    Implementation of a binary class classifier as scikit-learn `Pipeline` step.
+
+    Parameters
+    ----------
+    estimator : SKLearnPipelineModule
+        Estimator used to produce transformed or scored outputs.
+    """
 
     def __init__(self, estimator: SKLearnPipelineModule):
         self.estimator = estimator
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the provided instances."""
+        """
+        Fit the model on the provided instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This transformer instance after fitting.
+        """
         instances = check_type(FeatureData, instances)
         self.estimator.fit(instances.features, instances.labels)
         return self
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Convert instances by applying the fitted model."""
+        """
+        Convert instances by applying the fitted model.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         instances = check_type(FeatureData, instances)
 
         # get probabilities from the estimator
@@ -95,24 +183,67 @@ class BinaryClassifierTransformer(Transformer):
 
 
 class SklearnTransformer(Transformer):
-    """Implementation of a binary class classifier as scikit-learn `Pipeline` step."""
+    """
+    Implementation of a binary class classifier as scikit-learn `Pipeline` step.
+
+    Parameters
+    ----------
+    transformer : SklearnTransformerType
+        Transformer instance wrapped by this adapter.
+    """
 
     def __init__(self, transformer: SklearnTransformerType):
         self.transformer = transformer
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the provided instances."""
+        """
+        Fit the model on the provided instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This transformer instance after fitting.
+        """
         instances = check_type(FeatureData, instances)
         self.transformer.fit(instances.features, instances.labels)
         return self
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Convert instances by applying the fitted model."""
+        """
+        Convert instances by applying the fitted model.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         instances = check_type(FeatureData, instances)
         return instances.replace_as(FeatureData, features=self.transformer.transform(instances.features))
 
     def fit_apply(self, instances: InstanceData) -> FeatureData:
-        """Combine call to `.fit()` followed by `.apply()`."""
+        """
+        Combine call to `.fit()` followed by `.apply()`.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(FeatureData, instances)
         return instances.replace_as(
             FeatureData, features=self.transformer.fit_transform(instances.features, instances.labels)
@@ -120,33 +251,83 @@ class SklearnTransformer(Transformer):
 
 
 class FunctionTransformer(Transformer):
-    """Implementation of a transformer function as scikit-learn `Pipeline` step."""
+    """
+    Implementation of a transformer function as scikit-learn `Pipeline` step.
+
+    Parameters
+    ----------
+    func : Callable
+        Callable used to transform input instances.
+    """
 
     def __init__(self, func: Callable):
         self.func = func
 
     def apply(self, instances: InstanceData) -> FeatureData:
-        """Call the custom defined function on the feature data instances and use output as features."""
+        """
+        Call the custom defined function on the feature data instances and use output as features.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(FeatureData, instances)
         return instances.replace(features=self.func(instances.features))
 
 
 class Tee(Transformer):
-    """Implementation of a custom transformer allowing to perform two separate tasks on a given input."""
+    """
+    Implementation of a custom transformer allowing to perform two separate tasks on a given input.
+
+    Parameters
+    ----------
+    transformers : list[Transformer]
+        Collection of transformers applied in sequence or parallel.
+    """
 
     def __init__(self, transformers: list[Transformer]):
         super().__init__()
         self.transformers = transformers
 
     def fit(self, instances: InstanceData) -> Self:
-        """Delegate `fit()` to all specified transformers."""
+        """
+        Delegate `fit()` to all specified transformers.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This tee transformer instance after delegating fit.
+        """
         for transformer in self.transformers:
             transformer.fit(instances)
 
         return self
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Delegate `apply()` to all specified transformers."""
+        """
+        Delegate `apply()` to all specified transformers.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         for transformer in self.transformers:
             transformer.apply(instances)
 
@@ -154,11 +335,17 @@ class Tee(Transformer):
 
 
 class TransformerWrapper(Transformer):
-    """Base class for a transformer wrapper.
+    """
+    Base class for a transformer wrapper.
 
     This class is derived from `AdvancedTransformer` and has a default implementation of all functions
     by forwarding the call to the wrapped transformer. A subclass may add or change functionality
     by overriding functions.
+
+    Parameters
+    ----------
+    wrapped_transformer : Transformer
+        Value passed via ``wrapped_transformer``.
     """
 
     def __init__(self, wrapped_transformer: Transformer):
@@ -166,31 +353,88 @@ class TransformerWrapper(Transformer):
         self.wrapped_transformer = wrapped_transformer
 
     def fit(self, instances: InstanceData) -> Self:
-        """Delegate calls to underlying wrapped transformer but return the Wrapper instance."""
+        """
+        Delegate calls to underlying wrapped transformer but return the Wrapper instance.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This wrapper instance after delegating fit.
+        """
         self.wrapped_transformer.fit(instances)
         return self
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Delegate calls to underlying wrapped transformer but return the Wrapper instance."""
+        """
+        Delegate calls to underlying wrapped transformer but return the Wrapper instance.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         return self.wrapped_transformer.apply(instances)
 
 
 class NumpyTransformer(TransformerWrapper):
-    """Implementation of a transformer wrapper."""
+    """
+    Implementation of a transformer wrapper.
+
+    Parameters
+    ----------
+    transformer : Transformer
+        Transformer instance wrapped by this adapter.
+    header : list[str] | None
+        Value passed via ``header``.
+    """
 
     def __init__(self, transformer: Transformer, header: list[str] | None):
         super().__init__(transformer)
         self.header = header
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Extend the instances with the desired header data, call base `apply`."""
+        """
+        Extend the instances with the desired header data, call base `apply`.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         instances = super().apply(instances)
         if self.header:
             instances = instances.replace(header=self.header)
         return instances
 
     def fit_apply(self, instances: InstanceData) -> InstanceData:
-        """Extend the instances with the desired header data, call base `fit_apply`."""
+        """
+        Extend the instances with the desired header data, call base `fit_apply`.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         instances = super().fit_apply(instances)
         if self.header:
             instances = instances.replace(header=self.header)
@@ -198,10 +442,28 @@ class NumpyTransformer(TransformerWrapper):
 
 
 class CsvWriter(Transformer):
-    """Implementation of a transformation step in a scikit-learn Pipeline that writes to CSV.
+    """
+    Implementation of a transformation step in a scikit-learn Pipeline that writes to CSV.
 
     This might be used to obtain temporary or intermediate results for logging or debugging
     purposes.
+
+    Parameters
+    ----------
+    path : Path
+        Filesystem path used by this operation.
+    include : list[str] | None
+        Value passed via ``include``.
+    header : list[str] | None
+        Value passed via ``header``.
+    include_labels : bool
+        Whether to include labels in logged output.
+    include_meta : bool
+        Value passed via ``include_meta``.
+    include_input : bool
+        Whether to include original inputs in logged output.
+    include_batch : bool
+        Value passed via ``include_batch``.
     """
 
     def __init__(
@@ -278,17 +540,40 @@ class CsvWriter(Transformer):
             writer.writerow(chain(*row))
 
     def fit_apply(self, instances: InstanceDataType) -> InstanceDataType:
-        """Provide required `fit_apply()` and return all instances.
+        """
+        Provide required `fit_apply()` and return all instances.
 
         Since the CsvWriter is implemented as a step (Transformer) in the pipeline, it should support
         the `fit_apply` method which is called on all transformers of the pipeline.
 
         We don't need to actually fit or transform anything, so we simply return the instances (as is).
+
+        Parameters
+        ----------
+        instances : InstanceDataType
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceDataType
+            Instance data object produced by this operation.
         """
         return instances
 
     def apply(self, instances: InstanceData) -> FeatureData:
-        """Write numpy feature vector to CSV output file."""
+        """
+        Write numpy feature vector to CSV output file.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(FeatureData, instances)
 
         LOG.info(f'writing CSV file: {self.path}')
@@ -310,7 +595,8 @@ class CsvWriter(Transformer):
 
 
 def as_transformer(transformer_like: Any) -> Transformer:
-    """Provide a `Transformer` instance of the provided transformer like input.
+    """
+    Provide a `Transformer` instance of the provided transformer like input.
 
     For any transformer-like object, wrap if necessary, and return a `Transformer`.
 
@@ -320,8 +606,15 @@ def as_transformer(transformer_like: Any) -> Transformer:
     - a scikit-learn style estimator, which implements `fit()` and `predict_proba()`; or
     - a callable which takes an `np.ndarray` argument and returns another `np.ndarray`.
 
-    :param transformer_like: the object to wrap or return
-    :return: a `Transformer` instance
+    Parameters
+    ----------
+    transformer_like : Any
+        Object to convert to the internal Transformer interface.
+
+    Returns
+    -------
+    Transformer
+        Equivalent object adapted to the internal ``Transformer`` interface.
     """
     if isinstance(transformer_like, Transformer):
         # The component already supports all necessary methods, through the `Transformer` interface.

--- a/lir/transform/composite.py
+++ b/lir/transform/composite.py
@@ -14,14 +14,25 @@ class CategoricalCompositeTransformer(Transformer):
     Composite transformer.
 
     Incoming data is categorized by a category field. For each category, a separate transformer is used.
+
+    Parameters
+    ----------
+    factory : Callable[[], Transformer]
+        Value passed via ``factory``.
+    category_field : str
+        Value passed via ``category_field``.
     """
 
     def __init__(self, factory: Callable[[], Transformer], category_field: str):
         """
         Initialize the composite transformer.
 
-        :param factory: a callable that takes a category field and returns a transformer.
-        :param category_field: the category field to use
+        Parameters
+        ----------
+        factory : Callable[[], Transformer]
+            Value passed via ``factory``.
+        category_field : str
+            Value passed via ``category_field``.
         """
         self.factory = factory
         self.category_field = category_field
@@ -42,7 +53,15 @@ class CategoricalCompositeTransformer(Transformer):
         """
         Fit the transformer for all categories found in `instances`.
 
-        :param instances: a set of instances
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            This composite transformer instance after fitting category models.
         """
         # reset
         self._transformers = {}
@@ -60,8 +79,15 @@ class CategoricalCompositeTransformer(Transformer):
         """
         Apply the specialized transformers for all instances in `instances`, based on their categories.
 
-        :param instances: a set of instances
-        :return: the transformed instances
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
         """
         if self._category_shape is None:
             raise ValueError('apply() called before fit()')

--- a/lir/transform/distance.py
+++ b/lir/transform/distance.py
@@ -6,7 +6,8 @@ from lir.util import check_type
 
 
 class ElementWiseDifference(Transformer):
-    """Calculate the element-wise absolute difference between pairs.
+    """
+    Calculate the element-wise absolute difference between pairs.
 
     Takes an array of sample pairs and returns the element-wise absolute difference.
 
@@ -19,7 +20,19 @@ class ElementWiseDifference(Transformer):
     """
 
     def apply(self, instances: InstanceData) -> FeatureData:
-        """Calculate the absolute difference between all elements in the instance data (pairs)."""
+        """
+        Calculate the absolute difference between all elements in the instance data (pairs).
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(PairedFeatureData, instances)
         if instances.n_ref_instances != 1 or instances.n_trace_instances != 1:
             raise ValueError(
@@ -31,7 +44,8 @@ class ElementWiseDifference(Transformer):
 
 
 class ManhattanDistance(Transformer):
-    """Calculate the Manhattan distance between pairs.
+    """
+    Calculate the Manhattan distance between pairs.
 
     Takes a PairedFeatureData object or a FeatureData object and returns the manhattan distance.
 
@@ -40,12 +54,22 @@ class ManhattanDistance(Transformer):
 
     If the input is a FeatureData object, it is assumed that it contains the element-wise differences, and the sum over
     these differences is calculated.
-
-    :returns: a FeatureData object with features of shape (n, 1)
     """
 
     def apply(self, instances: InstanceData) -> FeatureData:
-        """Calculate the Manhattan distance between all elements in the instance data (pairs)."""
+        """
+        Calculate the Manhattan distance between all elements in the instance data (pairs).
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(FeatureData, instances)
 
         # if the data are paired instances, calculate the element wise difference first
@@ -60,7 +84,8 @@ class ManhattanDistance(Transformer):
 
 
 class EuclideanDistance(Transformer):
-    """Calculate the Euclidean distance between pairs.
+    """
+    Calculate the Euclidean distance between pairs.
 
     Takes a PairedFeatureData object or a FeatureData object and returns the euclidean distance.
 
@@ -72,12 +97,22 @@ class EuclideanDistance(Transformer):
 
     In yaml configurations, it can be used by specifying `euclidean_distance`, e.g.:
     `scoring: euclidean_distance`
-
-    :returns: a FeatureData object with features of shape (n, 1)
     """
 
     def apply(self, instances: InstanceData) -> FeatureData:
-        """Calculate the Euclidean distance between all elements in the instance data (pairs)."""
+        """
+        Calculate the Euclidean distance between all elements in the instance data (pairs).
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        FeatureData
+            FeatureData object parsed from the source.
+        """
         instances = check_type(FeatureData, instances)
 
         # if the data are paired instances, calculate the element wise difference first

--- a/lir/transform/distance.py
+++ b/lir/transform/distance.py
@@ -13,7 +13,8 @@ class ElementWiseDifference(Transformer):
     Expects:
     - a PairedFeatureData object with n_trace_instances=1 and n_ref_instances=1;
 
-    Returns:
+    Returns
+    -------
     - a copy of the FeatureData object with features of shape (n, f)
     """
 

--- a/lir/transform/pairing.py
+++ b/lir/transform/pairing.py
@@ -8,7 +8,8 @@ from lir.util import check_type
 
 
 class PairingMethod(ABC):
-    """Base class for pairing methods.
+    """
+    Base class for pairing methods.
 
     A pairing method should implement the `pair()` function.
     """
@@ -31,20 +32,41 @@ class PairingMethod(ABC):
         are 0=different source, 1=same source.
         Any other attributes are combined into tuples.
 
-        :param instances: An array of instance features, with one row per instance.
-        :param n_trace_instances: Number of instances per trace.
-        :param n_ref_instances: Number of instances per reference source.
-        :return: instance pairs
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+        n_trace_instances : int
+            Number of trace instances to include in each pairing.
+        n_ref_instances : int
+            Number of reference instances to include in each pairing.
+
+        Returns
+        -------
+        PairedFeatureData
+            FeatureData object parsed from the source.
         """
         raise NotImplementedError
 
 
 class SourcePairing(PairingMethod):
-    """Construct pairs of sources (i.e. classes) from an array of instances.
+    """
+    Construct pairs of sources (i.e. classes) from an array of instances.
 
     While pairing at instance level results in pairs of instances, some same-source and some different-source, pairing
     at source level results in pairing of multiple instances of source A against multiple instances of source B, where A
     and B can be same-source or different-source.
+
+    Parameters
+    ----------
+    same_source_limit : int | None
+        Limit for the number or fraction of same-source pairs.
+    different_source_limit : int | None
+        Limit for the number or fraction of different-source pairs.
+    ratio_limit : int | None
+        Maximum allowed ratio between same-source and different-source pairs.
+    seed : Any | int
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(
@@ -128,7 +150,8 @@ class SourcePairing(PairingMethod):
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
     ) -> PairedFeatureData:
-        """Pair sources.
+        """
+        Pair sources.
 
         Takes a FeatureData object that contains instances.
         Returns pairs as a PairedFeatureData object.
@@ -136,10 +159,19 @@ class SourcePairing(PairingMethod):
         The input is expected to have source_ids, that govern how pairs are compiled.
         The input instances may be used in a pair, either as a trace instance or as a reference instance.
 
-        :param instances: the set of instances to be paired
-        :param n_trace_instances: the number of trace instances in each pair
-        :param n_ref_instances: the number of reference instances in each pair
-        :return: paired instances
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+        n_trace_instances : int
+            Number of trace instances to include in each pairing.
+        n_ref_instances : int
+            Number of reference instances to include in each pairing.
+
+        Returns
+        -------
+        PairedFeatureData
+            FeatureData object parsed from the source.
         """
         instances = check_type(FeatureData, instances)
 
@@ -204,10 +236,22 @@ class SourcePairing(PairingMethod):
 
 
 class InstancePairing(PairingMethod):
-    """Construct pairs from a set of instances.
+    """
+    Construct pairs from a set of instances.
 
     Note that this pairing method may cause performance problems with large datasets,
     even if the number of instances in the output is limited.
+
+    Parameters
+    ----------
+    same_source_limit : int | None
+        Limit for the number or fraction of same-source pairs.
+    different_source_limit : int | None
+        Limit for the number or fraction of different-source pairs.
+    ratio_limit : float | None
+        Maximum allowed ratio between same-source and different-source pairs.
+    seed : int | None
+        Random seed controlling stochastic behaviour for reproducible results.
     """
 
     def __init__(
@@ -223,15 +267,22 @@ class InstancePairing(PairingMethod):
         Note that this pairing method may cause performance problems with large datasets,
         even if the number of instances in the output is limited.
 
-        :param same_source_limit: the maximum number of same source pairs (None = no limit)
-        :param different_source_limit: the maximum number of different source pairs (None = no limit; 'balanced' =
             number of same source pairs)
-        :param ratio_limit: maximum ratio between same source and different source pairs.
                 Ratio = ds pairs / ss pairs. The number of ds pairs will not exceed ratio_limit * ss pairs.
                 If both ratio and same_source_limit/different_source_limit are specified,
                 the number of pairs is chosen such that the ratio_limit is preserved and
                 the limit(s) are not exceeded, while taking as many pairs as possible within these constraints.
-        :param seed: seed to make pairing reproducible
+
+        Parameters
+        ----------
+        same_source_limit : int | None
+            Limit for the number or fraction of same-source pairs.
+        different_source_limit : int | None
+            Limit for the number or fraction of different-source pairs.
+        ratio_limit : float | None
+            Maximum allowed ratio between same-source and different-source pairs.
+        seed : int | None
+            Random seed controlling stochastic behaviour for reproducible results.
         """
         self._ss_limit = same_source_limit
         self._ds_limit = different_source_limit
@@ -241,7 +292,14 @@ class InstancePairing(PairingMethod):
 
     @property
     def rng(self) -> np.random.Generator:
-        """Obtain a random number generator using a provided seed."""
+        """
+        Obtain a random number generator using a provided seed.
+
+        Returns
+        -------
+        np.random.Generator
+            Random number generator initialized from the configured seed.
+        """
         if not self.__rng:
             self.__rng = np.random.default_rng(seed=self._seed)
         return self.__rng
@@ -252,12 +310,22 @@ class InstancePairing(PairingMethod):
         n_trace_instances: int = 1,
         n_ref_instances: int = 1,
     ) -> PairedFeatureData:
-        """Construct pairs.
+        """
+        Construct pairs.
 
-        :param instances: the set of instances to be paired
-        :param n_trace_instances: the number of trace instances in each pair (must be 1 for this pairing method)
-        :param n_ref_instances: the number of reference instances in each pair (must be 1 for this pairing method)
-        :return: paired instances
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+        n_trace_instances : int
+            Number of trace instances to include in each pairing.
+        n_ref_instances : int
+            Number of reference instances to include in each pairing.
+
+        Returns
+        -------
+        PairedFeatureData
+            FeatureData object parsed from the source.
         """
         instances = check_type(FeatureData, instances)
         if instances.source_ids is None:

--- a/lir/transform/pipeline.py
+++ b/lir/transform/pipeline.py
@@ -24,20 +24,42 @@ __all__ = [
 
 
 class Pipeline(Transformer):
-    """A pipeline of processing modules.
+    """
+    A pipeline of processing modules.
 
     A module may be a scikit-learn style transformer, estimator, or a LIR `Transformer`
+
+    Parameters
+    ----------
+    steps : list[tuple[str, Transformer | Any]]
+        Ordered transformer steps executed by this pipeline.
     """
 
     def __init__(self, steps: list[tuple[str, Transformer | Any]]):
-        """Initialize a new Pipeline object.
+        """
+        Initialize a new Pipeline object.
 
-        :param steps: the steps of the pipeline as a list of (name, module) tuples.
+        Parameters
+        ----------
+        steps : list[tuple[str, Transformer | Any]]
+            Ordered transformer steps executed by this pipeline.
         """
         self.steps = [(name, as_transformer(module)) for name, module in steps]
 
     def fit(self, instances: InstanceData) -> Self:
-        """Fit the model on the instance data."""
+        """
+        Fit the model on the instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        Self
+            The fitted pipeline instance.
+        """
         for _name, module in self.steps[:-1]:
             instances = module.fit_apply(instances)
 
@@ -48,20 +70,58 @@ class Pipeline(Transformer):
         return self
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Apply the fitted model on the instance data."""
+        """
+        Apply the fitted model on the instance data.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         for _name, module in self.steps:
             instances = module.apply(instances)
         return instances
 
     def fit_apply(self, instances: InstanceData) -> InstanceData:
-        """Combine fitting the transformer/estimator and applying the model to the instances."""
+        """
+        Combine fitting the transformer/estimator and applying the model to the instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         for _name, module in self.steps:
             instances = module.fit_apply(instances)
         return instances
 
 
 def parse_steps(config: ContextAwareDict | None, output_dir: Path) -> list[tuple[str, Transformer]]:
-    """Parse the defined pipeline steps in the configuration and return the initialized modules as a list."""
+    """
+    Parse the defined pipeline steps in the configuration and return the initialized modules as a list.
+
+    Parameters
+    ----------
+    config : ContextAwareDict | None
+        Configuration mapping used to construct this component.
+    output_dir : Path
+        Directory where generated outputs are written.
+
+    Returns
+    -------
+    list[tuple[str, Transformer]]
+        List of (name, module) tuples for the pipeline steps.
+    """
     if config is None:
         return []
     if not isinstance(config, ContextAwareDict):
@@ -82,7 +142,21 @@ def parse_steps(config: ContextAwareDict | None, output_dir: Path) -> list[tuple
 
 @config_parser
 def pipeline(config: ContextAwareDict, output_dir: Path) -> Pipeline:
-    """Construct a scikit-learn Pipeline based on the provided configuration."""
+    """
+    Construct a scikit-learn Pipeline based on the provided configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    output_dir : Path
+        Directory where generated outputs are written.
+
+    Returns
+    -------
+    Pipeline
+        The constructed pipeline instance.
+    """
     if config is None:
         return Pipeline([])
 
@@ -106,6 +180,23 @@ class LoggingPipeline(Pipeline):
     In addition, there may be columns for the input features and output of individual steps. These columns are named
     ``featuresI`` for input features or ``stepnameI`` for step output, where ``stepname`` is replaced by the name of the
     step, and ``I`` refers to the index of the feature value.
+
+    Parameters
+    ----------
+    steps : list[tuple[str, Transformer | Any]]
+        Ordered transformer steps executed by this pipeline.
+    output_file : PathLike
+        Destination file used to log intermediate pipeline output.
+    include_batch_number : bool
+        Whether to include the batch number in logged output.
+    include_labels : bool
+        Whether to include labels in logged output.
+    include_fields : list[str] | None
+        Additional instance fields to include in logged output.
+    include_steps : list[str] | None
+        Whether to include step names in logged output.
+    include_input : bool
+        Whether to include original inputs in logged output.
     """
 
     def __init__(
@@ -118,16 +209,27 @@ class LoggingPipeline(Pipeline):
         include_steps: list[str] | None = None,
         include_input: bool = True,
     ):
-        """Initialize a new LoggingPipeline instance.
+        """
+        Initialize a new LoggingPipeline instance.
 
-        :param steps: the steps of the pipeline as a list of (name, module) tuples.
-        :param output_file: the name of the generated output file
-        :param include_batch_number: (bool) whether the zero-indexed batch number should be included in the output,
             e.g. for cross-validation (defaults to True)
-        :param include_labels: (bool) whether the labels should be included, if available (defaults to True)
-        :param include_fields: a list of the names of extra fields to include (defaults to none)
-        :param include_steps: a list of steps to include (defaults to all)
-        :param include_input: (bool) whether to write the input features (defaults to True)
+
+        Parameters
+        ----------
+        steps : list[tuple[str, Transformer | Any]]
+            Ordered transformer steps executed by this pipeline.
+        output_file : PathLike
+            Destination file used to log intermediate pipeline output.
+        include_batch_number : bool
+            Whether to include the batch number in logged output.
+        include_labels : bool
+            Whether to include labels in logged output.
+        include_fields : list[str] | None
+            Additional instance fields to include in logged output.
+        include_steps : list[str] | None
+            Whether to include step names in logged output.
+        include_input : bool
+            Whether to include original inputs in logged output.
         """
         super().__init__(steps)
         self.output_file = Path(output_file)
@@ -139,7 +241,19 @@ class LoggingPipeline(Pipeline):
         self.n_batches = 0
 
     def apply(self, instances: InstanceData) -> InstanceData:
-        """Apply the pipeline to the incoming instances."""
+        """
+        Apply the pipeline to the incoming instances.
+
+        Parameters
+        ----------
+        instances : InstanceData
+            Input instances to be processed by this method.
+
+        Returns
+        -------
+        InstanceData
+            Instance data object produced by this operation.
+        """
         # initialize the csv builder
         write_mode = 'w' if self.n_batches == 0 else 'a'
         csv_builder = DataFileBuilderCsv(self.output_file, write_mode=write_mode)
@@ -186,7 +300,21 @@ class LoggingPipeline(Pipeline):
 
 @config_parser(reference=LoggingPipeline)
 def logging_pipeline(config: ContextAwareDict, output_dir: Path) -> Pipeline:
-    """Construct a scikit-learn Pipeline based on the provided configuration."""
+    """
+    Construct a scikit-learn Pipeline based on the provided configuration.
+
+    Parameters
+    ----------
+    config : ContextAwareDict
+        Configuration mapping used to construct this component.
+    output_dir : Path
+        Directory where generated outputs are written.
+
+    Returns
+    -------
+    Pipeline
+        Logging pipeline configured from the provided YAML section.
+    """
     if config is None:
         return Pipeline([])
 

--- a/lir/util.py
+++ b/lir/util.py
@@ -301,7 +301,7 @@ def validate_yaml(yaml_path: Path) -> None:
     ----------
     yaml_path : Path
         The path to the YAML file to be validated.
-    
+
     Raises
     ------
     FileNotFoundError

--- a/lir/util.py
+++ b/lir/util.py
@@ -68,7 +68,8 @@ FloatOrArray = TypeVar('FloatOrArray', np.ndarray, float)
 def odds_to_probability[FloatOrArray: (np.ndarray, float)](odds: FloatOrArray) -> FloatOrArray:
     """Convert odds to a probability.
 
-    Returns:
+    Returns
+    -------
     - 1                , for odds values of inf
     - odds / (1 + odds), otherwise
     """

--- a/lir/util.py
+++ b/lir/util.py
@@ -260,13 +260,25 @@ def warn_deprecated() -> None:
 
 
 def to_native_dict(cfg: Any) -> Any:
-    """Recursively convert confidence Configuration objects to native Python dicts/lists.
+    """
+    Recursively convert confidence Configuration objects to native Python dicts/lists.
 
     Accesses each value through cfg[key] to trigger reference resolution. The confidence ibrary doesn't have a built-in
     method for this, so we manually traverse and resolve.
 
     Similary to lir.config.base._expand, but this method returns native dicts/lists instead of
     ContextAwareDict/ContextAwareList.
+
+    Parameters
+    ----------
+    cfg : Any
+        The input configuration object, which can be a confidence Configuration, ConfigurationSequence, dict, list, or
+        any other type.
+
+    Returns
+    -------
+    Any
+        The input Configuration object converted to a native Python dict or list.
     """
     match cfg:
         case Configuration():
@@ -282,12 +294,22 @@ def to_native_dict(cfg: Any) -> Any:
 
 
 def validate_yaml(yaml_path: Path) -> None:
-    """Validate a YAML file against the schema.
+    """
+    Validate a YAML file against the schema.
 
-    :param yaml_path: path to the YAML file to validate
-    :raises FileNotFoundError: if the YAML or schema file doesn't exist
-    :raises yaml.YAMLError: if the YAML is invalid
-    :raises ValidationError: if the YAML doesn't conform to the schema
+    Parameters
+    ----------
+    yaml_path : Path
+        The path to the YAML file to be validated.
+    
+    Raises
+    ------
+    FileNotFoundError
+        If the YAML file or the schema file does not exist.
+    yaml.YAMLError
+        If the YAML file is not valid YAML.
+    ValidationError
+        If the YAML file does not conform to the schema.
     """
     schema_path = Path(__file__).parent.parent / 'lir.schema.json'
 

--- a/lir/util.py
+++ b/lir/util.py
@@ -20,7 +20,24 @@ AnyType = TypeVar('AnyType', bound=Any)
 
 
 def check_type[AnyType: Any](type_class: type[AnyType], v: Any, message: str | None = None) -> AnyType:
-    """Check if a given input is of the expected, specified type."""
+    """
+    Check if a given input is of the expected, specified type. If so, return the input value.
+
+    Parameters
+    ----------
+    type_class : type
+        The expected type of the input value.
+    v : Any
+        The input value to be checked against the expected type.
+    message : str, optional
+        An optional message to be included in the error if the type check fails. If not provided, a default message
+        indicating the expected type will be used.
+
+    Returns
+    -------
+    AnyType
+        The input value `v` if it is of the expected type.
+    """
     if isinstance(v, type_class):
         return v
     else:
@@ -29,7 +46,23 @@ def check_type[AnyType: Any](type_class: type[AnyType], v: Any, message: str | N
 
 
 def get_classes_from_Xy(X: np.ndarray, y: np.ndarray, classes: list[Any] | None = None) -> np.ndarray:
-    """Get the classification classes from labeled data."""
+    """
+    Get the classification classes from labeled data.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        The input data array, where rows correspond to samples and columns correspond to features.
+    y : np.ndarray
+        The target labels corresponding to each sample in `X`. This should be a 1-dimensional array.
+    classes : list[Any] | None, optional
+        An optional list of classes to be used. If not provided, the unique values in `y` will be used.
+
+    Returns
+    -------
+    np.ndarray
+        An array of unique classes found in `y` if `classes` is None; otherwise, an array of the provided `classes`.
+    """
     assert len(X.shape) >= 1, f'expected: X has at least 1 dimensions; found: {len(X.shape)} dimensions'
     assert len(y.shape) == 1, f'expected: y is a 1-dimensional array; found: {len(y.shape)} dimensions'
     assert X.shape[0] == y.size, f'dimensions of X and y do not match; found: {X.shape[0]} != {y.size}'
@@ -38,10 +71,20 @@ def get_classes_from_Xy(X: np.ndarray, y: np.ndarray, classes: list[Any] | None 
 
 
 def Xn_to_Xy(*Xn: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Convert Xn to Xy format.
+    """
+    Convert Xn to Xy format.
 
-    Xn is a format where samples are divided into separate variables based on class.
-    Xy is a format where all samples are concatenated, with an equal length variable y indicating class.
+    Parameters
+    ----------
+    *Xn : np.ndarray
+        Variable number of arrays, where each array corresponds to a class and contains the samples for that class.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        A tuple containing:
+        - X: A 2D array where all samples from the input arrays are concatenated together.
+        - y: A 1D array of the same length as the number of samples in X, where each element indicates the class label.
     """
     split_Xn = [np.asarray(X) for X in Xn]
     X = np.concatenate(split_Xn)
@@ -50,10 +93,23 @@ def Xn_to_Xy(*Xn: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 
 
 def Xy_to_Xn(X: np.ndarray, y: np.ndarray, classes: list[int] | None = None) -> list[np.ndarray]:
-    """Convert Xy to Xn format.
+    """
+    Convert Xy to Xn format.
 
-    Xn is a format where samples are divided into separate variables based on class.
-    Xy is a format where all samples are concatenated, with an equal length variable y indicating class.
+    Parameters
+    ----------
+    X : np.ndarray
+        A 2D array where rows correspond to samples and columns correspond to features.
+    y : np.ndarray
+        A 1D array of the same length as the number of samples in X, where each element indicates the class label.
+    classes : list[int] | None, optional
+        An optional list of class labels to be used for splitting the data. If not provided, the unique values in `y`
+        will be used as class labels.
+
+    Returns
+    -------
+    list[np.ndarray]
+        A list of arrays, where each array corresponds to a class and contains the samples for that class.
     """
     if classes is None:
         classes = [0, 1]
@@ -66,12 +122,19 @@ FloatOrArray = TypeVar('FloatOrArray', np.ndarray, float)
 
 
 def odds_to_probability[FloatOrArray: (np.ndarray, float)](odds: FloatOrArray) -> FloatOrArray:
-    """Convert odds to a probability.
+    """
+    Convert odds to a probability.
+
+    Parameters
+    ----------
+    odds : FloatOrArray
+        The odds to be converted to probability.
 
     Returns
     -------
-    - 1                , for odds values of inf
-    - odds / (1 + odds), otherwise
+    FloatOrArray
+        The input odds converted to probability. This is 1 if the input odds is infinity, and otherwise calculated as
+        odds / (1 + odds).
     """
     inf_values = odds == np.inf
     with np.errstate(invalid='ignore'):
@@ -81,36 +144,109 @@ def odds_to_probability[FloatOrArray: (np.ndarray, float)](odds: FloatOrArray) -
 
 
 def probability_to_odds[FloatOrArray: (np.ndarray, float)](p: FloatOrArray) -> FloatOrArray:
-    """Convert a probability to odds."""
+    """
+    Convert a probability to odds.
+
+    Parameters
+    ----------
+    p : FloatOrArray
+        The probability to be converted to odds.
+
+    Returns
+    -------
+    FloatOrArray
+        The input probability converted to odds. This is infinity if the input probability is 1, and otherwise
+        calculated as p / (1 - p).
+    """
     with np.errstate(divide='ignore'):
         return p / (1 - p)
 
 
 def probability_to_logodds[FloatOrArray: (np.ndarray, float)](p: FloatOrArray) -> FloatOrArray:
-    """Convert probability values to their log odds with base 10."""
+    """
+    Convert probability values to their log odds with base 10.
+
+    Parameters
+    ----------
+    p : FloatOrArray
+        The probability values to be converted to log odds.
+
+    Returns
+    -------
+    FloatOrArray
+        The input probability values converted to log odds with base 10.
+    """
     with np.errstate(divide='ignore'):
         complement = 1 - p
         return np.log10(p) - np.log10(complement)
 
 
 def logodds_to_probability[FloatOrArray: (np.ndarray, float)](log_odds: FloatOrArray) -> FloatOrArray:
-    """Convert 10-base logarithm of odds to probability."""
+    """
+    Convert 10-base logarithm of odds to probability.
+
+    Parameters
+    ----------
+    log_odds : FloatOrArray
+        The 10-base logarithm of odds to be converted to probability.
+
+    Returns
+    -------
+    FloatOrArray
+        The input 10-base logarithm of odds converted to probability.
+    """
     return odds_to_probability(logodds_to_odds(log_odds))
 
 
 def logodds_to_odds[FloatOrArray: (np.ndarray, float)](log_odds: FloatOrArray) -> FloatOrArray:
-    """Convert 10-base logarithm odds to odds."""
+    """
+    Convert 10-base logarithm odds to odds.
+
+    Parameters
+    ----------
+    log_odds : FloatOrArray
+        The 10-base logarithm of odds to be converted to odds.
+
+    Returns
+    -------
+    FloatOrArray
+        The input 10-base logarithm of odds converted to odds.
+    """
     with np.errstate(divide='ignore'):
         return 10**log_odds
 
 
 def odds_to_logodds[FloatOrArray: (np.ndarray, float)](odds: FloatOrArray) -> FloatOrArray:
-    """Convert odds to 10-base logarithm odds."""
+    """
+    Convert odds to 10-base logarithm odds.
+
+    Parameters
+    ----------
+    odds : FloatOrArray
+        The odds to be converted to 10-base logarithm odds.
+
+    Returns
+    -------
+    FloatOrArray
+        The input odds converted to 10-base logarithm odds.
+    """
     return np.log10(odds)
 
 
 def ln_to_log10[FloatOrArray: (np.ndarray, float)](ln_data: FloatOrArray) -> FloatOrArray:
-    """Convert natural logarithm to 10-base logarithm."""
+    """
+    Convert natural logarithm to 10-base logarithm.
+
+    Parameters
+    ----------
+    ln_data : FloatOrArray
+        Data in natural logarithm form to be converted to 10-base logarithm.
+
+    Returns
+    -------
+    FloatOrArray
+        The input data converted from natural logarithm to 10-base logarithm.
+    """
     return np.log10(np.e) * ln_data
 
 
@@ -174,13 +310,28 @@ def validate_yaml(yaml_path: Path) -> None:
 
 
 class Bind(partial):
-    """Wrap `partial` to support the ellipsis (...) as a placeholder.
+    """
+    Wrap `partial` to support the ellipsis (...) as a placeholder.
 
     Can be used to fix parameters not at the end of the list of parameters (which is a limitation of partial).
     """
 
     def __call__(self, *args: Any, **keywords: Any) -> Any:
-        """Extend `partial` and accept the ellipsis as a placeholder."""
+        """
+        Extend `partial` and accept the ellipsis as a placeholder.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments to be passed to the original function.
+        **keywords
+            Keyword arguments to be passed to the original function.
+
+        Returns
+        -------
+        Any
+            A new function with the same behavior as the original function, but with the specified parameters fixed.
+        """
         keywords = {**self.keywords, **keywords}
         iargs = iter(args)
         args = tuple(next(iargs) if arg is ... else arg for arg in self.args)

--- a/lir/visualization.py
+++ b/lir/visualization.py
@@ -9,7 +9,22 @@ from lir.plotting import savefig
 def _save_or_plot(
     ax: Any | None, base_path: Path | None, filename: str, plot_func: Callable[[Any, Any], None], *args: Any
 ) -> None:
-    """Plot to an axis or save plot to file."""
+    """
+    Plot to an axis or save plot to file.
+
+    Parameters
+    ----------
+    ax : Any | None
+        The axis to plot on, if provided.
+    base_path : Path | None
+        The base path to save the plot, if ax is not provided.
+    filename : str
+        The filename to save the plot as, if ax is not provided.
+    plot_func : Callable[[Any, Any], None]
+        The function that generates the plot, taking an axis or figure and data as arguments.
+    *args : Any
+        Additional arguments to pass to the plot function.
+    """
     if ax is not None:
         plot_func(ax, *args)
     elif base_path is not None:
@@ -22,20 +37,64 @@ def _save_or_plot(
 
 
 def pav(base_path: Path | None, llrdata: LLRData, ax: Any | None = None) -> None:
-    """Generate and handle a PAV plot, either saving to a file or plotting on a given axis."""
+    """
+    Generate and handle a PAV plot, either saving to a file or plotting on a given axis.
+
+    Parameters
+    ----------
+    base_path : Path | None
+        The base path to save the plot, if ax is not provided.
+    llrdata : LLRData
+        The data to be plotted.
+    ax : Any | None, optional
+        The axis to plot on, if provided. If None, the plot will be saved to a file, by default None.
+    """
     _save_or_plot(ax, base_path, 'pav.png', lambda obj, data: obj.pav(data), llrdata)
 
 
 def ece(base_path: Path | None, llrdata: LLRData, ax: Any | None = None) -> None:
-    """Generate and handle an ECE plot, either saving to a file or plotting on a given axis."""
+    """
+    Generate and handle an ECE plot, either saving to a file or plotting on a given axis.
+
+    Parameters
+    ----------
+    base_path : Path | None
+        The base path to save the plot, if ax is not provided.
+    llrdata : LLRData
+        The data to be plotted.
+    ax : Any | None, optional
+        The axis to plot on, if provided. If None, the plot will be saved to a file, by default None.
+    """
     _save_or_plot(ax, base_path, 'ece.png', lambda obj, data: obj.ece(data), llrdata)
 
 
 def lr_histogram(base_path: Path | None, llrdata: LLRData, ax: Any | None = None) -> None:
-    """Generate and handle a histogram plot of likelihood ratios, either saving to file or plotting on an axis."""
+    """
+    Generate and handle a histogram plot of likelihood ratios, either saving to file or plotting on an axis.
+
+    Parameters
+    ----------
+    base_path : Path | None
+        The base path to save the plot, if ax is not provided.
+    llrdata : LLRData
+        The data to be plotted.
+    ax : Any | None, optional
+        The axis to plot on, if provided. If None, the plot will be saved to a file, by default None.
+    """
     _save_or_plot(ax, base_path, 'histogram.png', lambda obj, data: obj.lr_histogram(data), llrdata)
 
 
 def llr_interval(base_path: Path | None, llrdata: LLRData, ax: Any | None = None) -> None:
-    """Generate and handle a Score-LR plot, either saving to file or plotting on an axis."""
+    """
+    Generate and handle a Score-LR plot, either saving to file or plotting on an axis.
+
+    Parameters
+    ----------
+    base_path : Path | None
+        The base path to save the plot, if ax is not provided.
+    llrdata : LLRData
+        The data to be plotted.
+    ax : Any | None, optional
+        The axis to plot on, if provided. If None, the plot will be saved to a file, by default None.
+    """
     _save_or_plot(ax, base_path, 'llr_interval.png', lambda obj, data: obj.llr_interval(data), llrdata)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:b71db4eb0f46d729e6e5840f3429d6c27cfa43be22698976e3f7c78fb4fb7846"
+content_hash = "sha256:55baeccf85686de8a12827d778f1951fea981dd7b2dc5ec060a01bd9789898e9"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.15"
@@ -1845,6 +1845,21 @@ dependencies = [
 files = [
     {file = "numpy_typing_compat-20251206.2.3-py3-none-any.whl", hash = "sha256:bfa2e4c4945413e84552cbd34a6d368c88a06a54a896e77ced760521b08f0f61"},
     {file = "numpy_typing_compat-20251206.2.3.tar.gz", hash = "sha256:18e00e0f4f2040fe98574890248848c7c6831a975562794da186cf4f3c90b935"},
+]
+
+[[package]]
+name = "numpydoc"
+version = "1.10.0"
+requires_python = ">=3.10"
+summary = "Sphinx extension to support docstrings in Numpy format"
+groups = ["dev"]
+dependencies = [
+    "sphinx>=6",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+]
+files = [
+    {file = "numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b"},
+    {file = "numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:55baeccf85686de8a12827d778f1951fea981dd7b2dc5ec060a01bd9789898e9"
+content_hash = "sha256:3715a415d432bcb33f71e7053418bcc95d0a723f81cef0a19da5617fa0d6dd6f"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.15"
@@ -87,20 +87,6 @@ dependencies = [
 files = [
     {file = "arviz-0.23.4-py3-none-any.whl", hash = "sha256:c46c7faf8a06abadc9b5b64000584062ecbc20c2298e2bd6dfba04bb01a684ca"},
     {file = "arviz-0.23.4.tar.gz", hash = "sha256:611be826995066036c9443ea98d11486c279ef3da3b6cdc5c0816fab434115b9"},
-]
-
-[[package]]
-name = "astroid"
-version = "3.3.11"
-requires_python = ">=3.9.0"
-summary = "An abstract syntax tree for Python with inference support."
-groups = ["dev"]
-dependencies = [
-    "typing-extensions>=4; python_version < \"3.11\"",
-]
-files = [
-    {file = "astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"},
-    {file = "astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce"},
 ]
 
 [[package]]
@@ -2966,22 +2952,6 @@ dependencies = [
 files = [
     {file = "sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"},
     {file = "sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3"},
-]
-
-[[package]]
-name = "sphinx-autodoc2"
-version = "0.5.0"
-requires_python = ">=3.8"
-summary = "Analyse a python project and create documentation for it."
-groups = ["dev"]
-dependencies = [
-    "astroid<4,>=2.7",
-    "tomli; python_version < \"3.11\"",
-    "typing-extensions",
-]
-files = [
-    {file = "sphinx_autodoc2-0.5.0-py3-none-any.whl", hash = "sha256:e867013b1512f9d6d7e6f6799f8b537d6884462acd118ef361f3f619a60b5c9e"},
-    {file = "sphinx_autodoc2-0.5.0.tar.gz", hash = "sha256:7d76044aa81d6af74447080182b6868c7eb066874edc835e8ddf810735b6565a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "myst-parser>=5.0.0",
     "jupyter-sphinx>=0.5.3",
     "types-requests>=2.32.4.20250913",
+    "numpydoc>=1.10.0",
 ]
 
 [tool.pdm]
@@ -58,7 +59,7 @@ version = {source = "scm"}
 [tool.pdm.scripts]
 all = {composite = ["check", "test"]}
 all_with_quicktest = {composite = ["check", "quicktest"]}
-check = {composite = ["format-check", "lint", "mypy"]}
+check = {composite = ["format-check", "lint", "mypy", "lint-docs"]}
 fix-all = {composite = ["lint-fix", "format-fix"]}
 lint = "ruff check lir tests docs"
 lint-fix = "ruff check --fix lir tests docs"
@@ -70,6 +71,7 @@ test = "coverage run --branch --source lir --module pytest --strict-markers test
 quicktest = {composite = ["test --testmon"]}
 test-coverage = "coverage report"
 lir = "python -m lir"
+lint-docs = {shell = 'numpydoc lint lir/*.py lir/*/*.py'}
 generate-docs= {composite = ["sphinx-build -M html docs build"]}
 serve-docs = {composite = ["generate-docs", "python -m http.server -d build/html"]}
 
@@ -119,9 +121,7 @@ lint.select = [
     "UP",   # pyupgrade
 ]
 lint.per-file-ignores = {"tests/*" = ["D"]}  # ignore missing docstrings in tests
-
-[tool.ruff.lint.pydocstyle]
-convention = "numpy"
+lint.pydocstyle.convention = "numpy"
 
 [tool.mypy]
 # allow redefinition of inferred / assigned types
@@ -135,3 +135,33 @@ strict_optional = true
 warn_unused_configs = true
 # do not warn about missing imports
 ignore_missing_imports = true
+
+[tool.numpydoc_validation]
+checks = [
+    "all",   # report on all checks, except the below
+    "GL08",
+    "EX01",
+    "SA01",
+    "ES01",
+]
+exclude_files = [
+    "lir/transform/*",
+    "lir/plotting/*",
+    "lir/metrics/*",
+    "lir/lrsystems/*",
+    "lir/experiments/*",
+    "lir/metrics/*",
+    "lir/datasets/*",
+    "lir/data/*",
+    "lir/config/*",
+    "lir/algorithms/*",
+
+    "lir/__init__.py",
+    "lir/aggregation.py",
+    "lir/bounding.py",
+    "lir/main.py",
+    "lir/persistence.py",
+    "lir/registry.py",
+    "lir/visualization.py",
+    "lir/util.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,5 @@ checks = [
     "PR01", # Parameters section
     "GL01", 
     "GL02",
-    "SS03",
     "SS05",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,5 +150,4 @@ exclude_files = [
     "lir/experiments/*",
     "lir/datasets/*",
     "lir/data/*",
-    "lir/config/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,5 +163,4 @@ exclude_files = [
     "lir/persistence.py",
     "lir/registry.py",
     "lir/visualization.py",
-    "lir/util.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,11 +143,13 @@ checks = [
     "EX01",
     "SA01",
     "ES01",
-]
-exclude_files = [
-    "lir/transform/*",
-    "lir/lrsystems/*",
-    "lir/experiments/*",
-    "lir/datasets/*",
-    "lir/data/*",
+    # After this line should be fixed
+    "RT01", # Return section
+    "PR01", # Parameters section
+    "GL01", 
+    "GL02",
+    "GL03",
+    "YD01", # Yield section
+    "SS03",
+    "SS05",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,5 +161,4 @@ exclude_files = [
     "lir/bounding.py",
     "lir/main.py",
     "lir/persistence.py",
-    "lir/registry.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,14 +147,10 @@ checks = [
 exclude_files = [
     "lir/transform/*",
     "lir/plotting/*",
-    "lir/metrics/*",
     "lir/lrsystems/*",
     "lir/experiments/*",
-    "lir/metrics/*",
     "lir/datasets/*",
     "lir/data/*",
     "lir/config/*",
     "lir/algorithms/*",
-
-    "lir/__init__.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,5 +157,4 @@ exclude_files = [
     "lir/algorithms/*",
 
     "lir/__init__.py",
-    "lir/aggregation.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,10 +143,5 @@ checks = [
     "EX01",
     "SA01",
     "ES01",
-    # After this line should be fixed
-    "RT01", # Return section
-    "PR01", # Parameters section
     "GL01", 
-    "GL02",
-    "SS05",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,5 +158,4 @@ exclude_files = [
 
     "lir/__init__.py",
     "lir/aggregation.py",
-    "lir/bounding.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dev = [
     "sphinx-rtd-theme>=3.1.0",
     "sphinxcontrib-napoleon>=0.7",
     "sphinx-jinja>=2.0.2",
-    "sphinx-autodoc2>=0.5.0",
     "myst-parser>=5.0.0",
     "jupyter-sphinx>=0.5.3",
     "types-requests>=2.32.4.20250913",
@@ -72,7 +71,8 @@ quicktest = {composite = ["test --testmon"]}
 test-coverage = "coverage report"
 lir = "python -m lir"
 lint-docs = {shell = 'numpydoc lint lir/*.py lir/*/*.py'}
-generate-docs= {composite = ["sphinx-build -M html docs build"]}
+apidoc = "sphinx-apidoc -f -e -M -o docs/api lir"
+generate-docs = {composite = ["apidoc", "sphinx-build -M html docs build"]}
 serve-docs = {composite = ["generate-docs", "python -m http.server -d build/html"]}
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,5 +160,4 @@ exclude_files = [
     "lir/aggregation.py",
     "lir/bounding.py",
     "lir/main.py",
-    "lir/persistence.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,6 @@ lint.ignore = [
     "D105",
     # do not enforce writing doc strings for `__init__()` methods
     "D107",
-    # disable section heading checks that contradict sphinx/myst
-    "D406", "D407",
 ]
 lint.isort.lines-after-imports = 2
 # List of enabled linting rules, for a complete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,5 +159,4 @@ exclude_files = [
     "lir/__init__.py",
     "lir/aggregation.py",
     "lir/bounding.py",
-    "lir/main.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,5 +151,4 @@ exclude_files = [
     "lir/datasets/*",
     "lir/data/*",
     "lir/config/*",
-    "lir/algorithms/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,5 +162,4 @@ exclude_files = [
     "lir/main.py",
     "lir/persistence.py",
     "lir/registry.py",
-    "lir/visualization.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ checks = [
     "PR01", # Parameters section
     "GL01", 
     "GL02",
-    "GL03",
     "SS03",
     "SS05",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ checks = [
     "GL01", 
     "GL02",
     "GL03",
-    "YD01", # Yield section
     "SS03",
     "SS05",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ checks = [
 ]
 exclude_files = [
     "lir/transform/*",
-    "lir/plotting/*",
     "lir/lrsystems/*",
     "lir/experiments/*",
     "lir/datasets/*",


### PR DESCRIPTION
Closes #251 

Use `numpydoc` to validate docstrings. Currently, most files are excluded due to the amount of errors. This can be seen a as a todo-list for improve the code style in these files.