### PR TITLE
registry: rename modules.logit to modules.logistic_calibrator

### DIFF
--- a/lir/resources/registry.yaml
+++ b/lir/resources/registry.yaml
@@ -61,7 +61,7 @@ modules:
   isotonic_calibrator:
     class: lir.algorithms.isotonic_regression.IsotonicRegression
     wrapper: lir.config.numpy_wrapper
-  logit: lir.algorithms.logistic_regression.LogitCalibrator
+  logistic_calibrator: lir.algorithms.logistic_regression.LogitCalibrator
   mcmc: lir.config.algorithms.mcmc
 
   # bounders


### PR DESCRIPTION
closes #332 