### PR TITLE
KDE calibrator should accept misleading predictions with log odds = inf or -inf #37

### DIFF
--- a/lir/algorithms/kde.py
+++ b/lir/algorithms/kde.py
@@ -194,9 +194,6 @@ class KDECalibrator(Transformer):
         instances = check_type(FeatureData, instances)
         instances = instances.replace_as(LLRData)
 
-        # check if data is sane
-        instances.check_misleading_finite()
-
         # KDE needs finite scale. Inf and negInf are treated as point masses at the extremes.
         # Remove them from data for KDE and calculate fraction data that is left.
         # LRs in finite range will be corrected for fractions in the apply function

--- a/tests/algorithms/test_kde.py
+++ b/tests/algorithms/test_kde.py
@@ -137,6 +137,28 @@ class TestKDECalibrator(unittest.TestCase):
         llrs_cal = calibrator.fit_apply(LLRData(features=X.reshape(-1, 1), labels=y))
         np.testing.assert_allclose(logodds_to_odds(llrs_cal.llrs), desired)
 
+    def test_accepts_misleading_infinite_values(self):
+        X = np.array(
+            [
+                0.25,
+                0.5,
+                np.inf,
+                0.75,
+                1.0,
+                -np.inf,
+                1.5,
+                2.0,
+            ]
+        )
+        y = np.array([0, 0, 0, 0, 0, 1, 1, 1])
+
+        calibrator = KDECalibrator(bandwidth='silverman')
+        llrs_cal = calibrator.fit_apply(LLRData(features=X.reshape(-1, 1), labels=y))
+
+        assert np.isposinf(llrs_cal.llrs[2])
+        assert np.isneginf(llrs_cal.llrs[5])
+        assert np.isfinite(llrs_cal.llrs[[0, 1, 3, 4, 6, 7]]).all()
+
 
 @pytest.mark.parametrize(
     'bandwidth_definition,expected_bandwidth',


### PR DESCRIPTION
Closes #37 