### PR TITLE
Data provider as callable

### DIFF
--- a/lir/config/data.py
+++ b/lir/config/data.py
@@ -1,11 +1,15 @@
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from functools import partial
 from pathlib import Path
+from typing import Any
 
 from lir import Transformer, registry
 from lir.config.base import (
+    ConfigParser,
     GenericConfigParser,
     YamlParseError,
     check_is_empty,
+    get_full_name,
     pop_field,
 )
 from lir.config.substitution import ContextAwareDict
@@ -118,6 +122,62 @@ def parse_data_strategy(cfg: ContextAwareDict, output_path: Path) -> DataStrateg
         )
 
     return parser.parse(cfg, output_path)
+
+
+class _DataProviderFunction(DataProvider):
+    def __init__(self, fn: Callable[[], InstanceData]):
+        self.fn = fn
+
+    def get_instances(self) -> InstanceData:
+        return self.fn()
+
+
+def data_provider[ReturnType: InstanceData](func: Callable[[ContextAwareDict, Path], ReturnType]) -> Callable:
+    """
+    Wrap a parsing function in a ``ConfigParser`` object using a decorator.
+
+    The :meth:`parse` method of the resulting :class:`~lir.config.base.ConfigParser` instance returns a
+    :class:`~lir.DataProvider` object that is invoked when needed.
+
+    This decorator can be used as follows:
+
+    .. code-block:: python
+
+        @data_provider
+        def foo(path: str, some_argument: int) -> InstanceData:
+            with open(path) as f:
+                ...
+                return FeatureData(...)
+
+    Parameters
+    ----------
+    func : Callable[[ContextAwareDict, Path], Any]
+        Function to wrap as a config parser.
+
+    Returns
+    -------
+    Callable
+        Decorator result or wrapped ``ConfigParser`` implementation.
+    """
+
+    class ConfigParserFunction(ConfigParser):
+        __doc__ = func.__doc__
+
+        def parse(
+            self,
+            config: ContextAwareDict,
+            output_dir: Path,
+        ) -> DataProvider:
+            return _DataProviderFunction(partial(func, **config))
+
+        def reference(self) -> str:
+            return get_full_name(func)
+
+        def __call__(self, *args: Any, **kwargs: Any) -> ReturnType:  # numpydoc ignore=RT01,PR01
+            """Call the decorated function directly, as if it was not decorated."""
+            return func(*args, **kwargs)
+
+    return ConfigParserFunction()
 
 
 def parse_data_provider(cfg: ContextAwareDict, output_path: Path) -> DataProvider:

--- a/lir/registry.py
+++ b/lir/registry.py
@@ -77,12 +77,14 @@ class ConfigParserLoader(ABC, Iterable):
 
     @staticmethod
     def _get_config_parser(
-        result_type: Any,
+        result_type: ConfigParser | type[ConfigParser] | Any,
         default_config_parser: Callable[[Any], ConfigParser] | None,
         args: Mapping[str, Any] | None = None,
     ) -> ConfigParser:
         args: Mapping[str, Any] = args or {}
-        if inspect.isclass(result_type) and issubclass(result_type, ConfigParser):
+        if isinstance(result_type, ConfigParser):
+            return result_type
+        elif inspect.isclass(result_type) and issubclass(result_type, ConfigParser):
             return result_type(**args)
         elif default_config_parser is not None:
             return default_config_parser(result_type, **args)

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lir import FeatureData, registry
+from lir.config.base import ConfigParser, ContextAwareDict
+from lir.config.data import data_provider
+
+
+@data_provider
+def load_data() -> FeatureData:
+    return FeatureData(features=np.arange(4).reshape((-1, 1)))
+
+
+@data_provider
+def load_data_with_args(first: int, second: int) -> FeatureData:
+    return FeatureData(features=np.array([[first], [second]]))
+
+
+def test_registry():
+    assert isinstance(load_data, ConfigParser)
+    assert load_data == registry.get('tests.config.test_data.load_data')
+
+
+@pytest.mark.parametrize(
+    'expected_result,dataset',
+    [
+        (np.arange(4), load_data()),
+        (np.arange(4), load_data.parse(ContextAwareDict([]), Path('/')).get_instances()),
+        (np.array([1, 2]), load_data_with_args(first=1, second=2)),
+        (
+            np.array([1, 2]),
+            load_data_with_args.parse(ContextAwareDict([], {'first': 1, 'second': 2}), Path('/')).get_instances(),
+        ),
+    ],
+)
+def test_load_data(expected_result: np.ndarray, dataset: FeatureData):
+    assert np.all(expected_result == dataset.features.reshape(-1))


### PR DESCRIPTION
Veel van de data providers die we op dit moment hebben kunnen worden gereduceerd tot een functie met enkele arguments die een InstanceData teruggeeft. De boilerplate eromheen is verhoudingsgewijs best veel. Deze PR maakt het mogelijk om een nieuwe dataset te implementeren met alleen de functie die het werk doet.

```py
@data_provider
def my_data_set(arg1: int, arg2: int) -> FeatureData:
    ...
    return FeatureData(...)
```

depends on #414 